### PR TITLE
Update mantid dependency to latest Mantid stable 6.11

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
 
   run:
     - python
-    - mantid=6.8.0
+    - mantid=6.11
     - numpy
     - scipy
     - pandas

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -13,9 +13,10 @@ Release Notes
 
 **Of interest to the Developer:**
 
-- PR #14 transition from pip to conda when installing dependency finddata
-- PR #13: Take average of intensity values with duplicate Q AND solve the issue with bg interpolation when bg q and sample q values are too close or identical
-- PR #12: switch from mantid to mantidworkbench conda package
+- PR 15: update Mantid dependency to 6.11
+- PR 14: transition from pip to conda when installing dependency finddata
+- PR 13: Take average of intensity values with duplicate Q AND solve the issue with bg interpolation when bg q and sample q values are too close or identical
+- PR 12: switch from mantid to mantidworkbench conda package
 
 1.0.0
 -----

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python=3.10
   - versioningit
-  - mantidworkbench=6.9.1
+  - mantidworkbench=6.11
   - pandas
   - xlsxwriter
   - neutrons::finddata=0.10


### PR DESCRIPTION
Upgraded Mantid in conda.recipe meta.yaml from 6.8.0 to 6.11 and MantidWorkbench in environment.yml from 6.9.1 to 6.11. This ensures compatibility with the latest features and fixes provided in version 6.11.

# Description of the changes


Check all that apply:
- [x] added [release notes](https://github.com/neutrons/usansred/blob/next/docs/source/releases.rst) (if not, provide an explanation in the work description)
- [ ] ~updated documentation~
- [ ] ~Source added/refactored~
- [ ] ~Added unit tests~
- [ ] ~Added integration tests~
- [ ] ~Verified that tests requiring the /SNS and /HFIR filesystems pass without fail~

**References:**
- Links to IBM EWM items: [7905](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=7905) (parent [7904](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=7904))

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/usansred/blob/next/docs/source/releases.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
