### PR TITLE
Upgrade mantid to 6.12

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,7 +14,7 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           channels: mantid/label/main,conda-forge,defaults

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,7 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           channels: mantid/label/main,conda-forge,defaults

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
 
   run:
     - python
-    - mantid=6.11
+    - mantid=6.12
     - numpy
     - scipy
     - pandas

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Release Notes
 
 **Of interest to the Developer:**
 
+- PR 18: update Mantid dependency to 6.12
 - PR 17: instructions to add/replace data files
 - PR 15: update Mantid dependency to 6.11
 - PR 14: transition from pip to conda when installing dependency finddata

--- a/environment.yml
+++ b/environment.yml
@@ -2,11 +2,10 @@ name: usansred
 channels:
   - mantid/label/main
   - conda-forge
-  - defaults
 dependencies:
   - python=3.10
   - versioningit
-  - mantidworkbench=6.11
+  - mantidworkbench=6.12
   - pandas
   - xlsxwriter
   - neutrons::finddata=0.10


### PR DESCRIPTION
# Description of the changes

Update mantid to the latest stable release, version 6.12.

I have tested by copying the folder `/SNS/USANS/IPTS-34017/shared/autoreduce` and running `reduceUSANS data.csv` and  the reduction runs without errors and the resulting plots in `reduced/summary.xlsx` look the same as in the original folder.

Check all that apply:
- [x] added [release notes](https://github.com/neutrons/usansred/blob/next/docs/source/releases.rst) (if not, provide an explanation in the work description)
- [ ] ~~updated documentation~~
- [ ] ~~Source added/refactored~~
- [ ] ~~Added unit tests~~
- [ ] ~~Added integration tests~~
- [ ] ~~Verified that tests requiring the /SNS and /HFIR filesystems pass without fail~~

**References:**
- Links to IBM EWM items: [Story 9420: [Cyber] [USANSRed] Remediation](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9420)
- Links to related issues or pull requests:

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/usansred/blob/next/docs/source/releases.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
