### PR TITLE
Update reduce.py to accommodate the windows csv format

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,7 +12,7 @@ Release Notes
 .. - PR #XYZ: one-liner description
 
 .. **Of interest to the Developer:**
-
+.. - PR 19: Explicitly denotes the encoding regardless of Windows and Linux. It won't change anything in Linux. 
 .. - PR 18: update Mantid dependency to 6.12
 .. - PR 17: instructions to add/replace data files
 .. - PR 17: change to absolute tolerance while subtracting background

--- a/src/usansred/reduce.py
+++ b/src/usansred/reduce.py
@@ -940,7 +940,7 @@ class Experiment:
 
         self.folder = os.path.dirname(csvFilePath)
 
-        with open(csvFilePath, newline="") as csvFile:
+        with open(csvFilePath, newline="", encoding='utf-8-sig') as csvFile:
             csvReader = csv.reader(csvFile, delimiter=",")
 
             for row in csvReader:


### PR DESCRIPTION
# Description of the changes

Add explicit encoding (utf-8) when reading CSV file. This will only affect the csv file created under Windows but won't change anything under Linux. 

Check all that apply:
- [ ] added [release notes](https://github.com/neutrons/usansred/blob/next/docs/source/releases.rst) (if not, provide an explanation in the work description)
- [ ] updated documentation
- [x] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/usansred/blob/next/docs/source/releases.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
