### PR TITLE
Step conda-verify insists on installing Mantid 6.12

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches: [next, qa, main]
     tags: ['v*']
+
 env:
   PKG_NAME: usansred
 
@@ -57,7 +58,15 @@ jobs:
           pixi-version: v0.49.0
 
       - name: Build conda package
-        run: pixi run conda-build
+        run: |
+          pixi run conda-build
+          ls ${{ env.PKG_NAME }}-*.conda
+
+      - name: Upload conda package as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact-conda-package
+          path: ${{ env.PKG_NAME }}-*.conda
 
       - name: Verify Conda Package
         uses: neutrons/conda-verify@main
@@ -68,12 +77,6 @@ jobs:
           extra-commands: |
             pixi run python -c "import mantid"
             pixi run python -c "import finddata"
-
-      - name: Upload conda package as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifact-conda-package
-          path: ${{ env.PKG_NAME }}-*.conda
 
 
   # Publish the package as a separate job so that the Github Actions webpage

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -60,23 +60,27 @@ jobs:
       - name: Build conda package
         run: |
           pixi run conda-build
-          ls ${{ env.PKG_NAME }}-*.conda
-
-      - name: Upload conda package as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifact-conda-package
-          path: ${{ env.PKG_NAME }}-*.conda
+          # prepare the local channel for verification
+          /bin/rm -rf /tmp/local-channel
+          mkdir -p /tmp/local-channel/linux-64
+          cp ${{ env.PKG_NAME }}-*.conda /tmp/local-channel/linux-64
 
       - name: Verify Conda Package
         uses: neutrons/conda-verify@main
         with:
           python-version: "3.11"
           package-name: ${{ env.PKG_NAME }}
+          local-channel: /tmp/local-channel
           extra-channels: mantid neutrons
           extra-commands: |
             pixi run python -c "import mantid"
             pixi run python -c "import finddata"
+
+      - name: Upload conda package as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact-conda-package
+          path: ${{ env.PKG_NAME }}-*.conda
 
 
   # Publish the package as a separate job so that the Github Actions webpage

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           pixi run conda-build
           # prepare the local channel for verification
-          /bin/rm -rf /tmp/local-channel
+          rm -rf /tmp/local-channel
           mkdir -p /tmp/local-channel/linux-64
           cp ${{ env.PKG_NAME }}-*.conda /tmp/local-channel/linux-64
 


### PR DESCRIPTION
# Description of the changes

This PR modifies the conda package verification workflow to use a local channel for testing. The change addresses an issue where the conda-verify step was insisting on installing Mantid 6.12 by preparing a local channel with the newly built package before verification.

- Creates a local channel directory structure in `/tmp/local-channel`
- Copies the built conda package to the local channel for verification
- Configures the conda-verify action to use the local channel


Check all that apply:
- [ ] ~updated documentation~
- [x] Source added/refactored~
- [ ] Added unit tests~
- [ ] ~Added integration tests~
- [ ] ~Verified that tests requiring the /SNS and /HFIR filesystems pass without fail~

**References:**
- ~Links to IBM EWM items:~

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
