### PR TITLE
Add workflow to sync dev branch with next without submodules

### DIFF
--- a/.github/workflows/dev_sync.yml
+++ b/.github/workflows/dev_sync.yml
@@ -1,0 +1,35 @@
+name: Branch dev in sync to branch next
+
+description: |
+  The `dev` branch is just `next` without the `.gitmodules` file, to allow for deploying
+  this package from source without attempting to also clone the test data repository.
+
+on:
+  push:
+    branches:
+      - next
+
+jobs:
+  sync_deploy_dev:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Needed to switch branches
+          ref: next       # Explicitly specify the branch to check out
+
+      - name: Configure git
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+      - name: Create dev branch
+        run: |
+          git checkout -B dev
+
+          # Remove submodule-related stuff
+          git rm -rf .gitmodules tests/mr_reduction-data || true
+          git commit -am "Sync from next without submodules" || echo "No changes"
+
+          git push origin dev --force


### PR DESCRIPTION
# Description of the changes
This PR adds a GitHub Actions workflow to automatically synchronize the `dev` branch with the `next` branch while excluding submodules. The workflow ensures that the `dev` branch remains a clean deployment-ready version of `next` without test data dependencies.

- Automated sync triggered on pushes to the `next` branch
- Removes `.gitmodules` and test data submodules from the synced branch
- Uses force push to maintain branch consistency

Check all that apply:
- [ ] ~updated documentation~
- [x] Source added/refactored
- [ ] ~Added unit tests~
- [ ] ~Added integration tests~
- [ ] ~Verified that tests requiring the /SNS and /HFIR filesystems pass without fail~

**References:**
- ~Links to IBM EWM items~

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
