### PR TITLE
revert to old upload until the actions is fixed

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -111,21 +111,15 @@ jobs:
           name: artifact-conda-package
 
       - name: Upload package to anaconda
-        uses: neutrons/conda-actions/publish@v1
-        with:
-          anaconda-token: ${{ secrets.ANACONDA_TOKEN }}
-          organization: neutrons
-          package-path: ${{ env.PKG_NAME }}-*.conda
-
-      - name: Remove old packages
-        if: github.ref == 'refs/heads/next'
-        uses: neutrons/conda-actions/pkg-remove@v1
-        with:
-          anaconda_token: ${{ secrets.ANACONDA_TOKEN }}
-          organization: neutrons
-          package_name: ${{ env.PKG_NAME }}
-          label: ${{ env.CONDA_LABEL }}
-          keep: 5
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+          IS_RC: ${{ contains(github.ref, 'rc') }}
+        run: |
+          # label is main or rc depending on the tag-name
+          CONDA_LABEL="main"
+          if [ "${IS_RC}" = "true" ]; then CONDA_LABEL="rc"; fi
+          echo pushing ${{ github.ref }} with label $CONDA_LABEL
+          pixi run anaconda upload --label $CONDA_LABEL --user neutrons ${{ env.PKG_NAME }}-*.conda
 
   # Trigger GitLab dev deploy pipeline
   deploy-dev:

--- a/pixi.lock
+++ b/pixi.lock
@@ -8,8 +8,6 @@ environments:
     - url: https://prefix.dev/pixi-build-backends/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -493,8 +491,6 @@ environments:
     - url: https://prefix.dev/pixi-build-backends/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -7131,9 +7127,10 @@ packages:
   timestamp: 1767817860341
 - pypi: ./
   name: usansred
-  version: 1.4.0.dev1
+  version: 1.4.0rc2
   sha256: 5e6a2bdf4ca4169b3c180eda8e4d473bd49391b905eee60ea99c498cd39d6158
   requires_python: '>=3.11'
+  editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
   sha256: 26e53b42f7fa1127e6115a35b91c20e15f75984648b88f115136f27715d4a440
   md5: 946e3571aaa55e0870fec0dea13de3bf


### PR DESCRIPTION
# Description of the changes
Revert release publishing mechanism in the GitHub Actions pipeline, switching away from the neutrons/conda-actions publish/remove actions and back to uploading via the anaconda-client CLI executed through Pixi.


# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
