### PR TITLE
the scan range is independent of the excluded run numbers

### DIFF
--- a/src/usansred/reduce.py
+++ b/src/usansred/reduce.py
@@ -139,7 +139,7 @@ class Sample(BaseModel):
 
     def model_post_init(self, _context: Any) -> None:  # noqa ANN401
         """Post-validation initializer"""
-        for i in range(self.num_of_scans + len(self.exclude)):
+        for i in range(self.num_of_scans):
             if i + self.start_scan_num in self.exclude:
                 continue
             scan = Scan(


### PR DESCRIPTION
# Description of the changes
Adjusts Sample initialization so the scan range is determined solely by num_of_scans, rather than being expanded based on the number of excluded run numbers. This aligns the created scan list with a fixed [start_scan_num, start_scan_num + num_of_scans) range.

Check all that apply:
- [x] Source added/refactored

# :warning: Manual test for the reviewer
Uncompress  test data file 
[test_data_EWM_15493.zip](https://github.com/user-attachments/files/26100675/test_data_EWM_15493.zip), then go to directory `test_data_EWM_15493/` and run `reduceUSANS ./setup.json`. The reduction should proceed without raising any exceptions

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
