### PR TITLE
ability to set the header for count files

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -34,11 +34,11 @@ jobs:
         with:
           manifest-path: pyproject.toml
 
-      - name: Run unit tests
-        run: pixi run unit-test
+      - name: Run tests not using the data repo nor the SNS-mount
+        run: pixi run test-datalight
 
-      - name: Run integration tests
-        run: pixi run integration-test
+      - name: Run tests using the data repo but not the SNS-mount
+        run: pixi run test-datarepo
 
       - name: Combine coverage reports
         run: pixi run combine-coverage

--- a/pixi.lock
+++ b/pixi.lock
@@ -7127,8 +7127,8 @@ packages:
   timestamp: 1767817860341
 - pypi: ./
   name: usansred
-  version: 1.5.0.dev4
-  sha256: 15f251d4d432243ae2e7d97cf3cbf195f4c356a471d259d5e039078b0a799865
+  version: 1.5.0.dev5
+  sha256: eb2ec3df18c4bad6bd3ce2fa0044be00f3befcfd5da3c1c81baa14b314c1f120
   requires_python: '>=3.11'
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda

--- a/pixi.lock
+++ b/pixi.lock
@@ -7127,8 +7127,8 @@ packages:
   timestamp: 1767817860341
 - pypi: ./
   name: usansred
-  version: 1.4.0rc2
-  sha256: 5e6a2bdf4ca4169b3c180eda8e4d473bd49391b905eee60ea99c498cd39d6158
+  version: 1.5.0.dev4
+  sha256: 15f251d4d432243ae2e7d97cf3cbf195f4c356a471d259d5e039078b0a799865
   requires_python: '>=3.11'
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,8 +145,9 @@ build-docs = { cmd = 'sphinx-build -b html docs docs/_build', description = "Bui
 test-docs = { cmd = "sphinx-build -M doctest docs docs/_build", description = "Test building the documentation" }
 # Testing
 test = { description = "Run the test suite", cmd = "pytest" }
-unit-test = { description = "Run the unit tests", cmd = "python -m pytest -vv -m \"not datarepo and not sns_mounted\" --cov=src --cov-report=xml --cov-report=term-missing tests/ && mv .coverage .coverage.unit" }
-integration-test = { description = "Run the integration tests", cmd = "git submodule update --init && python -m pytest -vv -m \"datarepo\" --cov=src --cov-report=xml  --cov-report=term-missing tests/ && mv .coverage .coverage.integration" }
+test-datalight = { description = "Run tests not using the data repo nor the SNS mount", cmd = "COVERAGE_FILE=.coverage.datalight python -m pytest -vv -m \"not datarepo and not sns_mounted\" --cov=src --cov-report=term-missing tests/" }
+test-datarepo = { description = "Run tests using the data repo", cmd = "git submodule update --init && COVERAGE_FILE=.coverage.datarepo python -m pytest -vv -m \"datarepo and not sns_mounted\" --cov=src --cov-report=term-missing tests/" }
+combine-coverage = { description = "Combine coverage reports", cmd = "coverage combine" }
 # Packaging
 pypi-build = { cmd = "hatch build", description = "Build the package for PyPI" }
 conda-build-command = { cmd = "pixi build", description = "Build the conda package command" }
@@ -171,7 +172,6 @@ clean-all = { description = "Clean all artifacts", depends-on = [
   "clean-docs",
   "clean-pypi",
 ] }
-combine-coverage = { description = "Combine coverage reports", cmd = "coverage combine" }
 sync-version = { cmd = 'version=$(python -m versioningit); toml set tool.pixi.package.version "$version" --toml-path pyproject.toml', description = "Sync pyproject.toml version with Git version" }
 backup-toml = { cmd = "cp pyproject.toml pyproject.toml.bak", description = "Backup the pyproject.toml file" }
 reset-toml = { cmd = "cp pyproject.toml.bak pyproject.toml; rm pyproject.toml.bak", description = "Reset the pyproject.toml file to the original state" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ test-docs = { cmd = "sphinx-build -M doctest docs docs/_build", description = "T
 test = { description = "Run the test suite", cmd = "pytest" }
 test-datalight = { description = "Run tests not using the data repo nor the SNS mount", cmd = "COVERAGE_FILE=.coverage.datalight python -m pytest -vv -m \"not datarepo and not sns_mounted\" --cov=src --cov-report=term-missing tests/" }
 test-datarepo = { description = "Run tests using the data repo", cmd = "git submodule update --init && COVERAGE_FILE=.coverage.datarepo python -m pytest -vv -m \"datarepo and not sns_mounted\" --cov=src --cov-report=term-missing tests/" }
-combine-coverage = { description = "Combine coverage reports", cmd = "coverage combine" }
+combine-coverage = { description = "Combine coverage reports", cmd = "coverage combine && coverage xml" }
 # Packaging
 pypi-build = { cmd = "hatch build", description = "Build the package for PyPI" }
 conda-build-command = { cmd = "pixi build", description = "Build the conda package command" }

--- a/src/usansred/io/save.py
+++ b/src/usansred/io/save.py
@@ -1,0 +1,66 @@
+"""
+Utility functions for USANS reduction.
+As we add utilities, perhaps  we can split them into separater modules
+"""
+
+from mantid.simpleapi import DeleteWorkspace, SaveAscii, SumSpectra, mtd
+
+
+def save_ascii(input_workspace, file_path, header=None, **saveascii):
+    """Save a workspace to an ASCII file.
+
+    Parameters
+    ----------
+    input_workspace : str or Workspace
+        Input workspace to be summed before saving.
+    file_path : str or path-like
+        Destination file path for the ASCII output.
+    header : str, optional
+        Header text to insert or replace in the output file.
+        If provided, and it does not start with ``#``, it is prefixed with ``# ``.
+    **saveascii
+        Additional keyword arguments passed through to ``mantid.simpleapi.SaveAscii``.
+        If argument ``WriteSpectrumID`` is not supplied, it defaults to ``False``.
+    """
+    if "WriteSpectrumID" not in saveascii:
+        saveascii["WriteSpectrumID"] = False  # spectrum number notwritten for single-spectrum workspaces
+    SaveAscii(InputWorkspace=input_workspace, Filename=str(file_path), **saveascii)
+
+    if header is None:
+        return
+
+    header_line = header if header.startswith("#") else f"# {header}"
+    with open(file_path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    replaced = False
+    for i, line in enumerate(lines):
+        if line.startswith("#"):
+            lines[i] = header_line.rstrip("\n") + "\n"
+            replaced = True
+            break
+    # Fallback: if no comment line exists, prepend one.
+    if not replaced:
+        lines.insert(0, header_line.rstrip("\n") + "\n")
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.writelines(lines)
+
+
+def save_summed_spectra(input_workspace, file_path, header=None):
+    """Save the summed spectra of a workspace to an ASCII file.
+
+    Parameters
+    ----------
+    input_workspace : str or Workspace
+        Input workspace to be summed before saving.
+    file_path : str or path-like
+        Destination file path for the ASCII output.
+    header : str, optional
+        Header text to insert or replace in the output file.
+        If provided, and it does not start with ``#``, it is prefixed with ``# ``.
+    **saveascii
+        Additional keyword arguments passed through to ``mantid.simpleapi.SaveAscii``.
+        If argument ``WriteSpectrumID`` is not supplied, it defaults to ``False``.
+    """
+    workspace = SumSpectra(InputWorkspace=input_workspace, OutputWorkspace=mtd.unique_name())
+    save_ascii(workspace, file_path, header=header)
+    DeleteWorkspace(workspace)

--- a/src/usansred/reduce_USANS.py
+++ b/src/usansred/reduce_USANS.py
@@ -13,7 +13,6 @@ from mantid.simpleapi import (
     CropWorkspace,
     LoadEventNexus,
     Rebin,
-    SaveAscii,
     StepScan,
     SumSpectra,
     mtd,
@@ -21,6 +20,7 @@ from mantid.simpleapi import (
 from matplotlib import use
 
 from usansred import reduce
+from usansred.io.save import save_ascii, save_summed_spectra
 from usansred.summary import generate_report
 
 use("agg")
@@ -104,9 +104,8 @@ def main():
 
     # Produce ASCII data
     Rebin(InputWorkspace="USANS", Params="0,10,17000", OutputWorkspace="USANS")
-    SumSpectra(InputWorkspace="USANS", OutputWorkspace="summed")
     file_path = os.path.join(outdir, "%s_detector_trans.txt" % file_prefix)
-    SaveAscii(InputWorkspace="summed", Filename=file_path, WriteSpectrumID=False)
+    save_summed_spectra("USANS", file_path, header="TOF, COUNTS, ERROR")
 
     CropWorkspace(
         InputWorkspace="USANS",
@@ -114,9 +113,8 @@ def main():
         EndWorkspaceIndex=1023,
         OutputWorkspace="USANS_detector",
     )
-    SumSpectra(InputWorkspace="USANS_detector", OutputWorkspace="summed")
     file_path = os.path.join(outdir, "%s_detector.txt" % file_prefix)
-    SaveAscii(InputWorkspace="summed", Filename=file_path, WriteSpectrumID=False)
+    save_summed_spectra("USANS_detector", file_path, header="TOF, COUNTS, ERROR")
 
     CropWorkspace(
         InputWorkspace="USANS",
@@ -124,9 +122,8 @@ def main():
         EndWorkspaceIndex=2047,
         OutputWorkspace="USANS_trans",
     )
-    SumSpectra(InputWorkspace="USANS_trans", OutputWorkspace="summed")
     file_path = os.path.join(outdir, "%s_trans.txt" % file_prefix)
-    SaveAscii(InputWorkspace="summed", Filename=file_path, WriteSpectrumID=False)
+    save_summed_spectra("USANS_trans", file_path, header="TOF, COUNTS, ERROR")
 
     if load_monitors:
         Rebin(
@@ -135,7 +132,7 @@ def main():
             OutputWorkspace="USANS_monitors",
         )
         file_path = os.path.join(outdir, "%s_monitor.txt" % file_prefix)
-        SaveAscii(InputWorkspace="USANS_monitors", Filename=file_path, WriteSpectrumID=False)
+        save_ascii("USANS_monitors", file_path, header="TOF, COUNTS, ERROR")
 
     # Find whether we have a motor turning
     short_name = ""
@@ -165,11 +162,7 @@ def main():
                         OutputWorkspace="USANS_scan_monitor",
                     )
                     file_path = os.path.join(outdir, "%s_monitor_scan_%s.txt" % (file_prefix, short_name))
-                    SaveAscii(
-                        InputWorkspace="USANS_scan_monitor",
-                        Filename=file_path,
-                        WriteSpectrumID=False,
-                    )
+                    save_ascii("USANS_scan_monitor", file_path, header=f"{scan_var}, COUNTS, ERROR")
                     y_monitor = mtd["USANS_scan_monitor"].readY(0)
 
                 iq_file_path_simple = os.path.join(outdir, "%s_iq_%s_%s.txt" % (file_prefix, short_name, main_wl))
@@ -228,11 +221,7 @@ def main():
 
                     if i == 0:
                         file_path = os.path.join(outdir, "%s_detector_%s.txt" % (file_prefix, main_wl))
-                        SaveAscii(
-                            InputWorkspace="USANS_scan_detector",
-                            Filename=file_path,
-                            WriteSpectrumID=False,
-                        )
+                        save_ascii("USANS_scan_detector", file_path, header=f"{scan_var}, COUNTS, ERROR")
                         # json_file_path = os.path.join(outdir, "%s_plot_data.json" % file_prefix)
                         # SavePlot1DAsJson(
                         #     InputWorkspace="USANS_scan_detector", JsonFilename=json_file_path, PlotName="main_output"
@@ -292,11 +281,7 @@ def main():
                             outdir,
                             "%s_detector_scan_%s_peak_%s.txt" % (file_prefix, short_name, i),
                         )
-                        SaveAscii(
-                            InputWorkspace="USANS_scan_detector",
-                            Filename=file_path,
-                            WriteSpectrumID=False,
-                        )
+                        save_ascii("USANS_scan_detector", file_path, header=f"{scan_var}, COUNTS, ERROR")
                         for i_theta in range(len(x_data)):
                             q = 2.0 * math.pi * math.sin(x_data[i_theta] * math.pi / 180.0 / 3600.0) / wavelength[i - 1]
                             # if q<=0:
@@ -339,21 +324,12 @@ def main():
 
                     if i == 0:
                         file_path = os.path.join(outdir, "%s_trans_%s.txt" % (file_prefix, main_wl))
-                        SaveAscii(
-                            InputWorkspace="USANS_scan_trans",
-                            Filename=file_path,
-                            WriteSpectrumID=False,
-                        )
                     else:
                         file_path = os.path.join(
                             outdir,
                             "%s_trans_scan_%s_peak_%s.txt" % (file_prefix, short_name, i),
                         )
-                        SaveAscii(
-                            InputWorkspace="USANS_scan_trans",
-                            Filename=file_path,
-                            WriteSpectrumID=False,
-                        )
+                    save_ascii("USANS_scan_trans", file_path, header=f"{scan_var}, COUNTS, ERROR")
 
                 iq_fd.close()
                 iq_fd_simple.close()
@@ -425,8 +401,8 @@ def main():
     if not os.path.exists(autodir):
         os.makedirs(autodir)
 
-    exp = reduce.Experiment(autocsvfile)
-    exp.reduce(outputFolder=autodir)
+    exp = reduce.Experiment(config=autocsvfile)
+    exp.reduce(output_dir=autodir)
 
     generate_report(config_file_path=autocsvfile, output_dir=exp.outputFolder)
 

--- a/tests/unit/io/test_read.py
+++ b/tests/unit/io/test_read.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 from usansred.io.read import read_config
 from usansred.reduce import Experiment, Sample
 
-DATA_DIR = Path(__file__).parent.parent / "data"
+DATA_DIR = Path(__file__).parent.parent.parent / "data"
 
 
 def test_read_config_csv():

--- a/tests/unit/io/test_save.py
+++ b/tests/unit/io/test_save.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+from mantid.simpleapi import CreateWorkspace, LoadAscii
+from numpy.testing import assert_allclose
+
+from usansred.io.save import save_ascii, save_summed_spectra
+
+
+@pytest.fixture
+def sample_workspace():
+    x = np.tile(np.arange(10), 3)
+    y = np.repeat([10, 100, 1000], 10)
+    e = 0.1 * y
+    workspace = CreateWorkspace(DataX=x, DataY=y, DataE=e, NSpec=3, UnitX="TOF")
+    assert workspace.getNumberHistograms() == 3
+    assert workspace.getAxis(0).getUnit().unitID() == "TOF"
+    return workspace
+
+
+def test_save_ascii(tmp_path, sample_workspace):
+    file_path = str(tmp_path / "ascii_output.txt")
+    save_ascii(sample_workspace, file_path, header="TOF, COUNTS, ERROR")
+    data = LoadAscii(Filename=file_path)  # shape: (30, 3)
+    assert data.getNumberHistograms() == 3
+    for i in range(3):
+        x_vals = data.dataX(i)
+        y_vals = data.dataY(i)
+        e_vals = data.dataE(i)
+
+        assert_allclose(x_vals, np.arange(10))
+        assert_allclose(y_vals, 10 * 10**i * np.ones(10))
+        assert_allclose(e_vals, 0.1 * y_vals)
+    assert open(file_path, "r").readline() == "# TOF, COUNTS, ERROR\n"
+
+
+def test_saved_summed_spectra(tmp_path, sample_workspace):
+    file_path = str(tmp_path / "summed_spectra.txt")
+    save_summed_spectra(sample_workspace, file_path, header="TOF, COUNTS, ERROR")
+
+    data = LoadAscii(Filename=file_path)  # shape: (10, 3)
+    assert data.getNumberHistograms() == 1
+    x_vals = data.dataX(0)
+    y_vals = data.dataY(0)
+    e_vals = data.dataE(0)
+
+    assert_allclose(x_vals, np.arange(10))
+    assert_allclose(y_vals, 1110.0 * np.ones(10))
+    assert_allclose(e_vals, 100.504 * np.ones(10))
+
+    assert open(file_path, "r").readline() == "# TOF, COUNTS, ERROR\n"


### PR DESCRIPTION
# Description of the changes
TOF vs Count files such as `/SNS/USANS/IPTS-33974/shared/autoreduce/USANS_45723_detector.txt` and Motor vs Count files such as `/SNS/USANS/IPTS-33974/shared/autoreduce/USANS_45723_detector.txt` start with header `# X , Y , E Distribution=false` which doesn't provide any information.

Now TOF vs Count files will start with header `# TOF, COUNTS, ERROR` and Motor vs Count files will typically start with header `# BL1A:Mot:ARN, COUNTS, ERROR`

Check all that apply:
- [ ] ~updated documentation~
- [x] Source added/refactored
- [x] Added unit tests
- [ ] ~Added integration tests~
- [ ] ~Verified that tests requiring the /SNS and /HFIR filesystems pass without fail~

**References:**
- ~Links to IBM EWM items:~
- ~Links to related issues or pull requests:~

# :warning: Manual test for the reviewer
In a terminal, run:
```bash
python ./src/usansred/reduce_USANS.py /SNS/USANS/IPTS-33974/nexus/USANS_45723.nxs.h5 /tmp/autoreduce
```
The autoreduction will not complete but it will produce the TOF vs Count files as well as the Motor vs Count files. Check that their headers are `# TOF, COUNTS, ERROR` and `# BL1A:Mot:ARN, COUNTS, ERROR`, respectively

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
