### PR TITLE
Dump scaled data for all harmonics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,261 @@
+# Agent Instructions for usansred
+
+This repository contains **usansred**, the reduction backend for SNS USANS
+data. Keep guidance and examples specific to this package.
+
+`CLAUDE.md` currently delegates to this file with `@AGENTS.md`. That is useful
+for Claude Code, but tools that do not expand `@...` includes may only see the
+literal one-line `CLAUDE.md` file.
+
+## Core Rules
+
+- Read the relevant source and tests before changing behavior.
+- Keep edits scoped to the user request; avoid opportunistic refactors.
+- Use the Pixi environment for Python commands. Do not assume bare `python`
+  is available in the default shell.
+- Prefer existing project patterns: `logging`, Pydantic models in
+  `src/usansred/reduce.py`, dataclasses in `src/usansred/model.py`, and
+  pytest tests under `tests/`.
+- Add or update tests when changing reduction behavior, parsing, file output,
+  or public command behavior.
+- Use physical units in names, docstrings, and messages when relevant:
+  Q in `1/angstrom`, thickness in `cm`, wavelength in `angstrom`.
+
+## Environment
+
+This repository is managed with Pixi. PyCharm is configured to use the Pixi
+interpreter at:
+
+```bash
+./.pixi/envs/default/bin/python
+```
+
+Run Python, tests, and tools through Pixi:
+
+```bash
+pixi run python --version
+pixi run python -m pytest tests/unit/io/test_read.py
+pixi run test
+pixi run test-datalight
+pixi run build-docs
+```
+
+Useful project tasks are defined in `pyproject.toml` under `[tool.pixi.tasks]`.
+There are no `unit-test` or `integration-test` Pixi tasks unless they are added
+later.
+
+## Project Map
+
+```text
+src/usansred/
+├── model.py          # XYData, IQData, MonitorData dataclasses
+├── reduce.py         # Scan, Sample, CombinedSample, Experiment, CLI entry point
+├── reduce_USANS.py   # Mantid-based autoreduction/preprocessing workflow
+├── summary.py        # summary.xlsx report generation
+└── io/
+    ├── read.py       # CSV/JSON setup parsing
+    ├── save.py       # Mantid SaveAscii/SumSpectra helpers
+    └── usansred.json # JSON schema for setup files
+
+tests/
+├── data/             # small config fixtures
+├── unit/             # focused tests for models, reduction logic, io, summary
+├── integration/      # end-to-end reduction tests
+└── usansred-data/    # data repository fixture/submodule
+```
+
+## Technology Notes
+
+- Python target: `>=3.11`; Pixi currently provides Python 3.11.
+- Core runtime dependencies declared in `pyproject.toml` include `pydantic`,
+  `pandas`, `xlsxwriter`, `finddata`, and Mantid Workbench. Source code also
+  imports `numpy` and `scipy`; if dependency declarations are being edited,
+  verify whether those should be explicit rather than transitive.
+- Mantid is used in specific places:
+  - `src/usansred/reduce_USANS.py` uses `mantid.simpleapi` for preprocessing.
+  - `src/usansred/io/save.py` uses `SaveAscii`, `SumSpectra`, `DeleteWorkspace`,
+    and `mtd`.
+  - `tests/conftest.py` uses `mantid.simpleapi.config` for test data lookup.
+- Do not use Mantid's `Logger` unless the project adopts it. Existing code uses
+  Python's standard `logging` module.
+- The package is for USANS only. Do not mention EQSANS, GPSANS, BIOSANS, or
+  `drtsans` modules like `api.py` or `iq.py` in examples.
+
+## Common Workflows
+
+### Config Parsing
+
+Setup files are parsed by `src/usansred/io/read.py`.
+
+- CSV rows are `b/s,name,start_scan_num,num_of_scans,thickness[,exclude]`.
+- JSON files contain optional `background` and required `samples`.
+- JSON `exclude` is a list of scan numbers.
+- Scan numbers and thickness are cast in `read.py`, so tests may include numeric
+  strings as well as numbers.
+
+Example JSON setup:
+
+```json
+{
+  "background": {
+    "name": "Empty",
+    "start_scan_num": 36301,
+    "num_of_scans": 5,
+    "thickness": 0.1
+  },
+  "samples": [
+    {
+      "name": "A2_56C_3hr",
+      "start_scan_num": 36330,
+      "num_of_scans": 5,
+      "thickness": 0.1,
+      "exclude": [36331, 36332]
+    }
+  ]
+}
+```
+
+### Reduction Model
+
+The main reduction model is in `src/usansred/reduce.py`.
+
+- `Experiment` owns config loading, output directory selection, background, and
+  samples.
+- `Sample` creates `Scan` objects, stitches detector banks, rescales intensity,
+  optionally log-bins, subtracts background, and writes output files.
+- `Scan` loads monitor and detector ASCII files named like
+  `USANS_<run>_monitor_scan_ARN.txt` and
+  `USANS_<run>_detector_scan_ARN_peak_<bank>.txt`.
+- `CombinedSample` combines raw scan data from multiple samples before reduction.
+- `XYData`, `IQData`, and `MonitorData` live in `src/usansred/model.py`.
+
+Output names currently include:
+
+- `UN_<sample>_det_1_unscaled.txt`
+- `UN_<sample>_det_1.txt`
+- `UN_<sample>_det_1_lb.txt`
+- `UN_<sample>_det_1_lbs.txt`
+- `summary.xlsx`
+
+## Coding Standards
+
+- Use type hints for new or modified public functions.
+- Use NumPy/Sphinx-style docstrings for public functions/classes.
+- Prefer simple data structures already used by the codebase.
+- Use `logging.info`, `logging.warning`, `logging.error`, or
+  `logging.exception` consistently with existing modules.
+- Avoid `print()` in library code.
+- Preserve behavior around user data files and output paths unless the request
+  explicitly changes it.
+- Be careful with scientific calculations. When changing Q conversion,
+  Gaussian fitting, stitching, scaling, log binning, or error propagation,
+  explain the formula or assumption in the code or tests where it helps future
+  maintenance.
+
+Relevant local example:
+
+```python
+import logging
+
+from usansred.io.read import read_config
+from usansred.reduce import Experiment, Sample
+
+
+def load_samples(config_file: str) -> list[Sample]:
+    """Load sample definitions from a USANSRED setup file."""
+    experiment = Experiment(config_file=config_file)
+    config = read_config(config_file)
+    samples = config["samples"]
+    logging.info("Loaded %d samples from %s", len(samples), config_file)
+    return [Sample(**sample, experiment=experiment) for sample in samples]
+```
+
+## Testing Guidance
+
+Use pytest through Pixi:
+
+```bash
+pixi run python -m pytest tests/unit/io/test_read.py
+pixi run python -m pytest tests/unit/test_sample.py
+pixi run python -m pytest tests/integration/test_reduce.py
+pixi run test
+```
+
+Use existing fixtures from `tests/conftest.py`:
+
+- `mock_experiment`
+- `mock_experiment_2banks`
+- `data_server`
+
+Use configured markers from `pyproject.toml`:
+
+```python
+import pytest
+
+
+@pytest.mark.datarepo
+def test_reduces_reference_dataset(data_server):
+    ...
+
+
+@pytest.mark.sns_mounted
+def test_reads_sns_filesystem_data():
+    ...
+```
+
+Testing expectations:
+
+- Parser changes: add or update tests in `tests/unit/io/test_read.py`.
+- Schema changes: validate against `tests/data/example-config*.json` and, when
+  relevant, `tests/usansred-data/IPTS-30410/shared/setup.json`.
+- Data model changes: update `tests/unit/test_model.py`, `test_scan.py`,
+  `test_sample.py`, or `test_combined_sample.py`.
+- Summary/report changes: update `tests/unit/test_summary.py`.
+- CLI/end-to-end changes: update `tests/integration/test_reduce.py`.
+- Mantid save helper changes: update `tests/unit/io/test_save.py`.
+
+Use Arrange-Act-Assert style:
+
+```python
+def test_read_config_json_excludes_scans():
+    config_file = DATA_DIR / "example-config.json"
+
+    config = read_config(config_file)
+    samples = config["samples"]
+
+    assert samples[1]["name"] == "sample2"
+    assert samples[1]["exclude"] == [45307, 45308]
+```
+
+## Review Checklist
+
+Before finishing substantial changes, check:
+
+- Relevant tests pass through `pixi run python -m pytest ...`.
+- Ruff-sensitive issues are avoided: imports, unused arguments, broad exception
+  rules already configured in `pyproject.toml`.
+- JSON files parse with `pixi run python -m json.tool <file>`.
+- Public docs or examples are updated when user-facing behavior changes.
+- Existing dirty worktree changes that are unrelated to the task are preserved.
+
+## Documentation
+
+User documentation lives under `docs/source/`. The main reduction guide is
+`docs/source/user/reduce.rst`. Keep examples aligned with the actual CLI:
+
+```bash
+reduceUSANS setup.csv
+reduceUSANS setup.json
+reduceUSANS --help
+```
+
+When adding setup-file features, update both the parser tests and the user docs
+if the feature is user-facing.
+
+## Things Not To Copy From drtsans
+
+- Do not refer to `src/drtsans/api.py`, `src/drtsans/iq.py`, `IQmod`, or
+  `bin_intensity_into_q1d`.
+- Do not assume multiple SANS instruments; this package targets USANS.
+- Do not require Mantid `Logger`; use the logging style already present here.
+- Do not invent Pixi tasks that are not in `pyproject.toml`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,12 @@ pixi run test-datalight
 pixi run build-docs
 ```
 
+When the agent runtime is in a read-only filesystem sandbox, Pixi may still need
+to update metadata under `.pixi/envs/default/conda-meta/` before running even
+read-only-looking commands. If a `pixi run ...` command is needed in that
+context, request escalated execution up front rather than first running it in the
+read-only sandbox and retrying after the expected metadata-write failure.
+
 Useful project tasks are defined in `pyproject.toml` under `[tool.pixi.tasks]`.
 There are no `unit-test` or `integration-test` Pixi tasks unless they are added
 later.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/source/user/reduce.rst
+++ b/docs/source/user/reduce.rst
@@ -63,7 +63,7 @@ and descriptions for each property.
        "exclude": ["<integer|string>"]        // scan numbers to skip during reduction; default: []
      },
 
-     "save_all_harmonics": "<boolean>",        // save reduced data for higher harmonics; default: false
+     "save_all_harmonics": "<boolean>",        // optional; save reduced data for higher harmonics; default: false
      "binning": {
        "log_binning": "<boolean>",             // apply log binning to the reduced data; default: false
        "steps_per_decade": "<integer>"          // step per decade when log binning; default: 33

--- a/docs/source/user/reduce.rst
+++ b/docs/source/user/reduce.rst
@@ -29,34 +29,14 @@ Defining the Setup File
 
 First, create the setup file **in the same folder as the raw data**.
 
-| The setup file is a file that contains the information about the samples to be reduced.
-| Two formats are supported: CSV (comma separated values) and JSON.
+The setup file is a file that contains the information about the samples to be reduced.
+Two formats are supported: JSON and CSV (comma separated values).
+The CSV is supported for backward compatibility and it only supports the background and sample information,
+while the JSON format also supports additional configuration flags such `save_all_harmonics`.
 
-The columns for the CSV format are as follows:
-
-1. Sample type: either `b` for background (empty sample) or `s` for sample.
-2. Sample name: a name for your own reference.
-3. Starting scan number: the first scan number associated with this sample.
-4. Number of scans: the total number of scans associated with this sample, including the first one.
-   For instance: ``36308,5`` instructs ``reduceUSANS`` to reduce together runs ``36308``, ``36309``, ``36310``,  ``36311``, and ``36312``.
-5. Sample thickness: the thickness of the sample in centimeters.
-6. (Optional) Exclude scans: a list of scan numbers to be excluded from the reduction, separated by semicolons.
-   For example, ``36308;36310`` will exclude scans ``36308`` and ``36310`` from the reduction.
-
-An example ``setup.csv`` might look like:
-
-.. code-block:: bash
-
-   b,Empty,36301,5,0.1
-   s,A2_50C_3hr,36308,5,0.1
-   s,A2_52C_3hr,36316,5,0.1
-   s,A2_54C_3hr,36323,5,0.1
-   s,A2_56C_3hr,36330,5,0.1,36331;36332
-
-The JSON format provides the same information in a different layout.
+The JSON format provides the same information in a structured layout.
 A JSON setup file contains a required samples entry, optional background entry, and optional configuration flags.
-Each background and sample object contains the same information as the columns in the CSV format,
-but with descriptive keys.
+Each background and sample object contains descriptive keys for each field.
 
 A JSON schema (usansred.json) is provided in the repository to validate the JSON setup file.
 It contains valid input structures and types, default values for optional properties,
@@ -84,10 +64,6 @@ and descriptions for each property.
 
      "save_all_harmonics": "<boolean>"        // optional; save reduced data for higher harmonics; default: false
    }
-
-Note that the main difference is how excluded scans are represented:
-- in CSV, they are represented as a semicolon-separated string of scan numbers in the last (6th) column,
-- in JSON, they are represented as a list of integers under the key ``exclude``.
 
 For example, create a file named ``setup.json`` with the following content:
 
@@ -130,6 +106,31 @@ For example, create a file named ``setup.json`` with the following content:
      "save_all_harmonics": false
    }
 
+The CSV format provides the same information as flat rows. The columns are as follows:
+
+1. Sample type: either `b` for background (empty sample) or `s` for sample.
+2. Sample name: a name for your own reference.
+3. Starting scan number: the first scan number associated with this sample.
+4. Number of scans: the total number of scans associated with this sample, including the first one.
+   For instance: ``36308,5`` instructs ``reduceUSANS`` to reduce together runs ``36308``, ``36309``, ``36310``,  ``36311``, and ``36312``.
+5. Sample thickness: the thickness of the sample in centimeters.
+6. (Optional) Exclude scans: a list of scan numbers to be excluded from the reduction, separated by semicolons.
+   For example, ``36308;36310`` will exclude scans ``36308`` and ``36310`` from the reduction.
+
+An example ``setup.csv`` might look like:
+
+.. code-block:: bash
+
+   b,Empty,36301,5,0.1
+   s,A2_50C_3hr,36308,5,0.1
+   s,A2_52C_3hr,36316,5,0.1
+   s,A2_54C_3hr,36323,5,0.1
+   s,A2_56C_3hr,36330,5,0.1,36331;36332
+
+Note that the main difference is how excluded scans are represented:
+- in JSON, they are represented as a list of integers under the key ``exclude``,
+- in CSV, they are represented as a semicolon-separated string of scan numbers in the last (6th) column.
+
 Reducing the Data
 -----------------
 
@@ -137,9 +138,9 @@ Run the reducing script by passing the path to the JSON or CSV setup file.
 
 .. code-block:: bash
 
-   (usansred) $ reduceUSANS setup.csv
-   # or
    (usansred) $ reduceUSANS setup.json
+   # or
+   (usansred) $ reduceUSANS setup.csv
 
 Additional CLI options for ``reduceUSANS`` can be viewed in the terminal by running:
 

--- a/docs/source/user/reduce.rst
+++ b/docs/source/user/reduce.rst
@@ -59,7 +59,8 @@ and descriptions for each property.
        "name": "<string>",                    // required if background is present; background name
        "start_scan_num": "<integer|string>",  // required if background is present; run or scan number
        "num_of_scans": "<integer|string>",    // required if background is present; number of scans
-       "thickness": "<number|string>"         // required if background is present; thickness in cm
+       "thickness": "<number|string>",        // required if background is present; thickness in cm
+       "exclude": ["<integer|string>"]        // scan numbers to skip during reduction; default: []
      },
 
      "save_all_harmonics": "<boolean>",        // save reduced data for higher harmonics; default: false

--- a/docs/source/user/reduce.rst
+++ b/docs/source/user/reduce.rst
@@ -53,14 +53,37 @@ An example ``setup.csv`` might look like:
    s,A2_54C_3hr,36323,5,0.1
    s,A2_56C_3hr,36330,5,0.1,36331;36332
 
-The JSON format provides the same information in a different layout. A JSON setup file contains a background entry, and a samples entry,which is a list of sample objects.
-Each background and sample object contains the same information as the columns in the CSV format, but with descriptive keys:
+The JSON format provides the same information in a different layout.
+A JSON setup file contains a required samples entry, optional background entry, and optional configuration flags.
+Each background and sample object contains the same information as the columns in the CSV format,
+but with descriptive keys.
 
-- ``name`` (string)
-- ``start_scan_num`` (integer)
-- ``num_of_scans`` (integer)
-- ``thickness`` (float)
-- ``exclude`` (list of integers, optional)
+A JSON schema (usansred.json) is provided in the repository to validate the JSON setup file.
+It contains valid input structures and types, default values for optional properties,
+and descriptions for each property.
+
+.. code-block:: javascript
+
+   {
+     "samples": [
+       {
+         "name": "<string>",                    // required; sample name
+         "start_scan_num": "<integer|string>",  // required; run or scan number
+         "num_of_scans": "<integer|string>",    // required; number of scans
+         "thickness": "<number|string>",        // required; thickness in cm
+         "exclude": ["<integer|string>"]        // optional; scan numbers to skip during reduction; default: []
+       }
+     ],
+
+     "background": {
+       "name": "<string>",                    // required if background is present; background name
+       "start_scan_num": "<integer|string>",  // required if background is present; run or scan number
+       "num_of_scans": "<integer|string>",    // required if background is present; number of scans
+       "thickness": "<number|string>"         // required if background is present; thickness in cm
+     },
+
+     "save_all_harmonics": "<boolean>"        // optional; save reduced data for higher harmonics; default: false
+   }
 
 Note that the main difference is how excluded scans are represented:
 - in CSV, they are represented as a semicolon-separated string of scan numbers in the last (6th) column,
@@ -71,12 +94,6 @@ For example, create a file named ``setup.json`` with the following content:
 .. code-block:: json
 
    {
-     "background": {
-       "name": "Empty",
-       "start_scan_num": 36301,
-       "num_of_scans": 5,
-       "thickness": 0.1
-     },
      "samples": [
        {
          "name": "A2_50C_3hr",
@@ -103,7 +120,14 @@ For example, create a file named ``setup.json`` with the following content:
          "thickness": 0.1,
          "exclude": [36331, 36332]
        }
-     ]
+     ],
+     "background": {
+       "name": "Empty",
+       "start_scan_num": 36301,
+       "num_of_scans": 5,
+       "thickness": 0.1
+     },
+     "save_all_harmonics": false
    }
 
 Reducing the Data

--- a/docs/source/user/reduce.rst
+++ b/docs/source/user/reduce.rst
@@ -51,7 +51,7 @@ and descriptions for each property.
          "start_scan_num": "<integer|string>",  // required; run or scan number
          "num_of_scans": "<integer|string>",    // required; number of scans
          "thickness": "<number|string>",        // required; thickness in cm
-         "exclude": ["<integer|string>"]        // optional; scan numbers to skip during reduction; default: []
+         "exclude": ["<integer|string>"]        // scan numbers to skip during reduction; default: []
        }
      ],
 
@@ -62,8 +62,11 @@ and descriptions for each property.
        "thickness": "<number|string>"         // required if background is present; thickness in cm
      },
 
-     "save_all_harmonics": "<boolean>"        // optional; save reduced data for higher harmonics; default: false
-     "log_binning": "<boolean>"               // optional; apply log binning to the reduced data; default: false
+     "save_all_harmonics": "<boolean>",        // save reduced data for higher harmonics; default: false
+     "binning": {
+       "log_binning": "<boolean>",             // apply log binning to the reduced data; default: false
+       "steps_per_decade": "<integer>"          // step per decade when log binning; default: 33
+     }
    }
 
 For example, create a file named ``setup.json`` with the following content:
@@ -105,7 +108,10 @@ For example, create a file named ``setup.json`` with the following content:
        "thickness": 0.1
      },
      "save_all_harmonics": false,
-     "log_binning": false
+     "binning": {
+       "log_binning": false,
+       "steps_per_decade": 33
+     }
    }
 
 The old CSV format provides only part of the information that can be encoded in the JSON file.

--- a/docs/source/user/reduce.rst
+++ b/docs/source/user/reduce.rst
@@ -32,7 +32,7 @@ First, create the setup file **in the same folder as the raw data**.
 The setup file is a file that contains the information about the samples to be reduced.
 Two formats are supported: JSON and CSV (comma separated values).
 The CSV is supported for backward compatibility and it only supports the background and sample information,
-while the JSON format also supports additional configuration flags such `save_all_harmonics`.
+while the JSON format also supports additional configuration flags such as `save_all_harmonics`.
 
 The JSON format provides the same information in a structured layout.
 A JSON setup file contains a required samples entry, optional background entry, and optional configuration flags.
@@ -157,6 +157,17 @@ Additional CLI options for ``reduceUSANS`` can be viewed in the terminal by runn
 .. code-block:: bash
 
    (usansred) $ reduceUSANS --help
+   usage: reduceUSANS [-h] [-l] [-o OUTPUT] path
+
+   USANS Data Reduction
+
+   positional arguments:
+     path                         Path to the configuration file
+
+   options:
+     -h, --help                   show this help message and exit
+     -l, --logbin                 Enable log-binning of data during reduction. Option only valid for CSV files
+     -o OUTPUT, --output OUTPUT   Output folder for reduced data (default: current folder)
 
 Summary
 -------

--- a/docs/source/user/reduce.rst
+++ b/docs/source/user/reduce.rst
@@ -63,6 +63,7 @@ and descriptions for each property.
      },
 
      "save_all_harmonics": "<boolean>"        // optional; save reduced data for higher harmonics; default: false
+     "log_binning": "<boolean>"               // optional; apply log binning to the reduced data; default: false
    }
 
 For example, create a file named ``setup.json`` with the following content:
@@ -103,10 +104,12 @@ For example, create a file named ``setup.json`` with the following content:
        "num_of_scans": 5,
        "thickness": 0.1
      },
-     "save_all_harmonics": false
+     "save_all_harmonics": false,
+     "log_binning": false
    }
 
-The CSV format provides the same information as flat rows. The columns are as follows:
+The old CSV format provides only part of the information that can be encoded in the JSON file.
+Information is entered in rows, with items in a row separated by `,`:
 
 1. Sample type: either `b` for background (empty sample) or `s` for sample.
 2. Sample name: a name for your own reference.

--- a/pixi.lock
+++ b/pixi.lock
@@ -593,6 +593,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jsoncpp-1.9.6-hf42df4d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
@@ -777,11 +779,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/quickbayes-1.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rapidjson-1.1.0.post20240409-h3f2d84a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/roman-numerals-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/roman-numerals-py-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py311h902ca64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.3-py311hbe70eeb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/scooby-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/seekpath-2.1.0-pyhd8ed1ab_2.conda
@@ -6993,8 +6997,8 @@ packages:
   timestamp: 1767817860341
 - pypi: ./
   name: usansred
-  version: 1.5.0.dev20260417150023
-  sha256: c794ed1c9cbbad3a42bdb42a1e53f6b08d2966d2ed4690fca34ce1c495487be5
+  version: 1.6.0.dev20260504135122
+  sha256: 57c556a5211bf4f967937a04517d39e6f9a2e9eeb2edad01895af26166c1d396
   requires_python: '>=3.11'
 - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
   sha256: 26e53b42f7fa1127e6115a35b91c20e15f75984648b88f115136f27715d4a440

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ artifacts = [
   "reduction/usansred/**/*.yml",
   "reduction/usansred/**/*.yaml",
   "reduction/usansred/**/*.ini",
+  "src/usansred/**/*.json",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -122,6 +123,7 @@ pandas = "*"
 pydantic = "*"
 xlsxwriter = "*"
 finddata = { version = "=0.10.1", channel = "neutrons" }
+jsonschema = "*"
 
 # Conda packages (no PyPi) to be enumerated within the conda package to be built.
 [tool.pixi.package.run-dependencies]
@@ -131,6 +133,7 @@ pandas = "*"
 pydantic = "*"
 xlsxwriter = "*"
 finddata = { version = "=0.10.1", channel = "neutrons" }
+jsonschema = "*"
 
 [tool.pixi.package]
 name = "usansred"

--- a/src/usansred/io/read.py
+++ b/src/usansred/io/read.py
@@ -178,8 +178,6 @@ def config_from_json(json_path: str) -> dict:
         bg["thickness"] = float(bg["thickness"])
         bg["exclude"] = [int(x) for x in bg["exclude"]]
         bg["is_background"] = True
-    else:
-        logging.info("No background configuration found.")
 
     # Samples block: coerce to preferred types for easier processing
     for sample in config["samples"]:
@@ -212,4 +210,9 @@ def read_config(file_path: str) -> dict:
     elif ext.lower() == ".json":
         return config_from_json(file_path)
     else:
-        raise ValueError(f"Unsupported configuration file format: {ext}")
+        raise ValueError(f"Unsupported configuration file format: {ext}. Valid formats are .csv and .json.")
+
+
+def is_csv(file_path: str) -> bool:
+    _, ext = os.path.splitext(file_path)
+    return ext.lower() == ".csv"

--- a/src/usansred/io/read.py
+++ b/src/usansred/io/read.py
@@ -1,15 +1,113 @@
 # TODO: Modify to allow multiple backgrounds
-
+import json
 import logging
+import os
+from copy import deepcopy
+from importlib import resources
+
+from jsonschema import Draft202012Validator, validators
+from jsonschema import ValidationError as JsonSchemaValidationError
 
 
-def config_from_csv(csv_path: str) -> tuple[dict | None, list[dict]]:
+def _validator_with_defaults(validator_class: type[Draft202012Validator]) -> type[Draft202012Validator]:
+    """Create a JSON schema validator that inserts schema defaults."""
+    validate_properties = validator_class.VALIDATORS["properties"]
+    validate_required = validator_class.VALIDATORS["required"]
+
+    def set_defaults(validator, properties, instance, schema):  # noqa ANN001
+        if isinstance(instance, dict):
+            for property_name, subschema in properties.items():
+                if "default" in subschema and property_name not in instance:
+                    instance[property_name] = deepcopy(subschema["default"])
+
+        yield from validate_properties(validator, properties, instance, schema)
+
+    def validate_required_defaults(validator, required, instance, schema):  # noqa ANN001
+        if not isinstance(instance, dict):
+            yield from validate_required(validator, required, instance, schema)
+            return
+
+        properties = schema.get("properties", {})
+        for property_name in required:
+            if property_name in instance:
+                continue
+
+            subschema = properties.get(property_name, {})
+            if "default" in subschema:
+                instance[property_name] = deepcopy(subschema["default"])
+                continue
+
+            yield JsonSchemaValidationError(
+                f"Required property '{property_name}' is missing from input configuration "
+                "and no default value is defined in the schema."
+            )
+
+    return validators.extend(
+        validator_class,
+        {
+            "properties": set_defaults,
+            "required": validate_required_defaults,
+        },
+    )
+
+
+DefaultValidatingDraft202012Validator = _validator_with_defaults(Draft202012Validator)
+
+
+def _read_schema() -> dict:
+    """Read the JSON schema for USANSRED setup files."""
+    schema_path = resources.files("usansred.io").joinpath("usansred.json")
+    with schema_path.open("r", encoding="utf-8") as schema_file:
+        return json.load(schema_file)
+
+
+def _format_json_path(error: JsonSchemaValidationError) -> str:
+    """Format a JSON schema error path for user-facing messages."""
+    if not error.path:
+        return ""
+
+    path = "".join(f"[{item}]" if isinstance(item, int) else f".{item}" for item in error.path)
+    return path.lstrip(".")
+
+
+def _format_validation_error(error: JsonSchemaValidationError) -> str:
+    """Format a JSON schema validation error for setup-file users."""
+    path = _format_json_path(error)
+    prefix = f"{path}: " if path else ""
+
+    if (
+        error.validator == "additionalProperties"
+        and error.validator_value is False
+        and isinstance(error.instance, dict)
+    ):
+        allowed_properties = set(error.schema.get("properties", {}))
+        extra_properties = sorted(set(error.instance) - allowed_properties)
+        extras = ", ".join(repr(property_name) for property_name in extra_properties)
+        return f"{prefix}Additional properties are not allowed: {extras}"
+
+    return f"{prefix}{error.message}"
+
+
+def _validate_config(config: dict) -> None:
+    """Validate a reduction configuration and insert schema defaults."""
+    schema = _read_schema()
+    validator = DefaultValidatingDraft202012Validator(schema)
+    errors = sorted(validator.iter_errors(config), key=lambda error: list(error.path))
+    if not errors:
+        return
+
+    error = errors[0]
+    raise ValueError(_format_validation_error(error))
+
+
+def config_from_csv(csv_path: str) -> dict:
     """Reads the reduction configuration from a CSV file.
 
     Returns
     -------
-    tuple[dict | None, list[dict]]
-        A tuple containing the background configuration (or None) and a list of sample configurations.
+    dict
+        A dictionary with keys ``"background"`` (a dict or ``None``) and
+        ``"samples"`` (a list of dicts).
     """
     import csv
 
@@ -48,24 +146,25 @@ def config_from_csv(csv_path: str) -> tuple[dict | None, list[dict]]:
                 else:
                     samples.append(sample)
 
-    return background, samples
+    return {"background": background, "samples": samples}
 
 
-def config_from_json(json_path: str) -> tuple[dict | None, list[dict]]:
+def config_from_json(json_path: str) -> dict:
     """Reads the reduction configuration from a JSON file.
 
     Returns
     -------
-    tuple[dict | None, list[dict]]
-        A tuple containing the background configuration (or None) and a list of sample configurations.
+    dict
+        A dictionary with keys ``"background"`` (a dict or ``None``) and
+        ``"samples"`` (a list of dicts), among other entries
     """
-
-    import json
-
     with open(json_path, "r") as f:
-        data = json.load(f)
+        config = json.load(f)
 
-    bg = data.get("background")
+    _validate_config(config)
+
+    # Parse the background configuration
+    bg = config.get("background")
     if bg:
         try:
             background = {
@@ -84,12 +183,15 @@ def config_from_json(json_path: str) -> tuple[dict | None, list[dict]]:
     else:
         logging.info("No background sample found in the configuration.")
         background = None
+    config["background"] = background
 
-    _samples: list[dict] = data.get("samples")
+    _samples: list[dict] = config.get("samples")
     if not _samples:
         logging.info("No samples found in the configuration.")
-        return background, []
+        config["samples"] = []
+        return config
 
+    # Parse the sample configurations
     samples = []
     for s in _samples:
         try:
@@ -104,11 +206,11 @@ def config_from_json(json_path: str) -> tuple[dict | None, list[dict]]:
         except Exception as e:  # noqa E722
             logging.info(f"Error parsing sample {s}: {e}")
             # traceback.print_exc()
+    config["samples"] = samples
+    return config
 
-    return background, samples
 
-
-def read_config(file_path: str) -> tuple[dict | None, list[dict]]:
+def read_config(file_path: str) -> dict:
     """Wrapper function to read configuration from different file formats.
 
     Parameters
@@ -118,10 +220,10 @@ def read_config(file_path: str) -> tuple[dict | None, list[dict]]:
 
     Returns
     -------
-    tuple[dict | None, list[dict]]
-        A tuple containing the background configuration (or None) and a list of sample configurations.
+    dict
+        A dictionary with a minumum set of keys ``"background"`` (a dict or ``None``) and
+        ``"samples"`` (a list of dicts).
     """
-    import os
 
     _, ext = os.path.splitext(file_path)
     if ext.lower() == ".csv":

--- a/src/usansred/io/read.py
+++ b/src/usansred/io/read.py
@@ -4,6 +4,7 @@ import logging
 import os
 from copy import deepcopy
 from importlib import resources
+from typing import Any
 
 from jsonschema import Draft202012Validator, validators
 from jsonschema import ValidationError as JsonSchemaValidationError
@@ -98,6 +99,19 @@ def _validate_config(config: dict) -> None:
 
     error = errors[0]
     raise ValueError(_format_validation_error(error))
+
+
+def cast_to_bool(value: Any) -> bool:
+    """Convert common setup-file values to a boolean."""
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"", "0", "false", "f", "no", "n", "off"}:
+            return False
+        if normalized in {"1", "true", "t", "yes", "y", "on"}:
+            return True
+        raise ValueError(f"Cannot cast string value {value!r} to bool")
+
+    return bool(value)
 
 
 def config_from_csv(csv_path: str) -> dict:

--- a/src/usansred/io/read.py
+++ b/src/usansred/io/read.py
@@ -163,50 +163,24 @@ def config_from_json(json_path: str) -> dict:
 
     _validate_config(config)
 
-    # Parse the background configuration
+    # Background block: coerce to preferred types for easier processing
     bg = config.get("background")
     if bg:
-        try:
-            background = {
-                "name": bg["name"],
-                "start_scan_num": int(bg["start_scan_num"]),
-                "num_of_scans": int(bg["num_of_scans"]),
-                "thickness": float(bg["thickness"]),
-                "is_background": True,
-            }
-        except KeyError as e:
-            logging.info(f"Missing key in background configuration: {e}")
-            background = None
-        except (TypeError, ValueError) as e:
-            logging.info(f"Error parsing background configuration: {e}")
-            background = None
+        bg["start_scan_num"] = int(bg["start_scan_num"])
+        bg["num_of_scans"] = int(bg["num_of_scans"])
+        bg["thickness"] = float(bg["thickness"])
+        bg["exclude"] = [int(x) for x in bg["exclude"]]
+        bg["is_background"] = True
     else:
-        logging.info("No background sample found in the configuration.")
-        background = None
-    config["background"] = background
+        logging.info("No background configuration found.")
 
-    _samples: list[dict] = config.get("samples")
-    if not _samples:
-        logging.info("No samples found in the configuration.")
-        config["samples"] = []
-        return config
-
-    # Parse the sample configurations
-    samples = []
-    for s in _samples:
-        try:
-            sample = {
-                "name": s["name"],
-                "start_scan_num": int(s["start_scan_num"]),
-                "num_of_scans": int(s["num_of_scans"]),
-                "thickness": float(s["thickness"]),
-                "exclude": [int(x) for x in s.get("exclude", [])],
-            }
-            samples.append(sample)
-        except Exception as e:  # noqa E722
-            logging.info(f"Error parsing sample {s}: {e}")
-            # traceback.print_exc()
-    config["samples"] = samples
+    # Samples block: coerce to preferred types for easier processing
+    for sample in config["samples"]:
+        sample["start_scan_num"] = int(sample["start_scan_num"])
+        sample["num_of_scans"] = int(sample["num_of_scans"])
+        sample["thickness"] = float(sample["thickness"])
+        sample["exclude"] = [int(x) for x in sample["exclude"]]
+        sample["is_background"] = False
     return config
 
 

--- a/src/usansred/io/read.py
+++ b/src/usansred/io/read.py
@@ -140,13 +140,20 @@ def config_from_csv(csv_path: str) -> dict:
 
             if sample is not None:
                 if row[0] == "b":
-                    # Check if this sample is the empty sample
-                    sample["is_background"] = True
                     background = sample
                 else:
                     samples.append(sample)
 
-    return {"background": background, "samples": samples}
+    config = {"background": background, "samples": samples}
+    _validate_config(config)
+
+    # Add fields not in the schema
+    for sample in config["samples"]:
+        sample["is_background"] = False
+    if background is not None:
+        background["is_background"] = True
+
+    return config
 
 
 def config_from_json(json_path: str) -> dict:

--- a/src/usansred/io/usansred.json
+++ b/src/usansred/io/usansred.json
@@ -5,7 +5,7 @@
   "description": "Configuration schema for JSON setup files consumed by usansred.io.read.config_from_json.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["samples", "save_all_harmonics"],
+  "required": ["samples"],
   "properties": {
     "samples": {
       "description": "Sample configurations to reduce.",
@@ -17,6 +17,7 @@
     },
     "background": {
       "description": "Optional background sample configuration. If omitted or null, reduction proceeds without a configured background.",
+      "default": null,
       "anyOf": [
         {
           "$ref": "#/$defs/background"

--- a/src/usansred/io/usansred.json
+++ b/src/usansred/io/usansred.json
@@ -30,6 +30,16 @@
       "description": "Save reduced data for higher harmonics",
       "type": "boolean",
       "default": false
+    },
+    "log_binning": {
+      "description": "Enable logarithmic Q-binning of reduced data",
+      "examples": [0, 1, "", false, true],
+      "default": false,
+      "anyOf": [
+        {"type": "boolean"},
+        {"type": "integer"},
+        {"type": "string"}
+      ]
     }
   },
   "$defs": {

--- a/src/usansred/io/usansred.json
+++ b/src/usansred/io/usansred.json
@@ -72,6 +72,15 @@
         },
         "thickness": {
           "$ref": "#/$defs/thickness"
+        },
+        "exclude": {
+          "description": "Optional list of scan numbers to skip during reduction.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/scanNumber"
+          },
+          "default": []
         }
       }
     },

--- a/src/usansred/io/usansred.json
+++ b/src/usansred/io/usansred.json
@@ -31,15 +31,28 @@
       "type": "boolean",
       "default": false
     },
-    "log_binning": {
-      "description": "Enable logarithmic Q-binning of reduced data",
-      "examples": [0, 1, "", false, true],
-      "default": false,
-      "anyOf": [
-        {"type": "boolean"},
-        {"type": "integer"},
-        {"type": "string"}
-      ]
+    "binning": {
+      "description": "Binning configuration for the reduced data.",
+      "type": "object",
+      "additionalProperties": false,
+      "default": {},
+      "properties": {
+        "log_binning": {
+          "description": "Enable logarithmic Q-binning of reduced data",
+          "examples": [0, 1, "", false, true],
+          "default": false,
+          "anyOf": [
+            {"type": "boolean"},
+            {"type": "integer"},
+            {"type": "string"}
+          ]
+        },
+        "steps_per_decade": {
+          "description": "step per decade when log binning",
+          "type": "integer",
+          "default": 33
+        }
+      }
     }
   },
   "$defs": {

--- a/src/usansred/io/usansred.json
+++ b/src/usansred/io/usansred.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://neutrons.github.io/usansred/schemas/usansred.json",
+  "title": "USANSRED reduction configuration",
+  "description": "Configuration schema for JSON setup files consumed by usansred.io.read.config_from_json.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["samples", "save_all_harmonics"],
+  "properties": {
+    "samples": {
+      "description": "Sample configurations to reduce.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/sample"
+      }
+    },
+    "background": {
+      "description": "Optional background sample configuration. If omitted or null, reduction proceeds without a configured background.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/background"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "save_all_harmonics": {
+      "description": "Save reduced data for higher harmonics",
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "$defs": {
+    "background": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "start_scan_num", "num_of_scans", "thickness"],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/name"
+        },
+        "start_scan_num": {
+          "$ref": "#/$defs/scanNumber"
+        },
+        "num_of_scans": {
+          "$ref": "#/$defs/scanCount"
+        },
+        "thickness": {
+          "$ref": "#/$defs/thickness"
+        }
+      }
+    },
+    "sample": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "start_scan_num", "num_of_scans", "thickness"],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/name"
+        },
+        "start_scan_num": {
+          "$ref": "#/$defs/scanNumber"
+        },
+        "num_of_scans": {
+          "$ref": "#/$defs/scanCount"
+        },
+        "thickness": {
+          "$ref": "#/$defs/thickness"
+        },
+        "exclude": {
+          "description": "Optional list of scan numbers to skip during reduction.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/scanNumber"
+          },
+          "default": []
+        }
+      }
+    },
+    "name": {
+      "description": "Sample or background name.",
+      "type": "string",
+      "minLength": 1
+    },
+    "scanNumber": {
+      "description": "Run or scan number. Numeric strings are accepted because read.py casts these values with int().",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 0
+        },
+        {
+          "type": "string",
+          "pattern": "^(0|[1-9][0-9]*)$"
+        }
+      ]
+    },
+    "scanCount": {
+      "description": "Number of scans in the sequence. Numeric strings are accepted because read.py casts this value with int().",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "type": "string",
+          "pattern": "^[1-9][0-9]*$"
+        }
+      ]
+    },
+    "thickness": {
+      "description": "Sample thickness in centimeters. Numeric strings are accepted because read.py casts this value with float().",
+      "oneOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        {
+          "type": "string",
+          "pattern": "^\\+?(?:(?:0*[1-9][0-9]*)(?:\\.[0-9]*)?|(?:0*\\.[0-9]*[1-9][0-9]*))(?:[eE][+-]?[0-9]+)?$"
+        }
+      ]
+    }
+  }
+}

--- a/src/usansred/io/usansred.json
+++ b/src/usansred/io/usansred.json
@@ -52,6 +52,12 @@
           "description": "step per decade when log binning",
           "type": "integer",
           "default": 33
+        },
+        "q_min": {
+          "description": "Minimum Q value (1/Angstrom) for the log-binned output grid",
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "default": 1e-6
         }
       }
     }

--- a/src/usansred/reduce.py
+++ b/src/usansred/reduce.py
@@ -10,7 +10,7 @@ import numpy as np
 from pydantic import BaseModel, Field
 from scipy.optimize import curve_fit
 
-from usansred.io.read import is_csv, read_config
+from usansred.io.read import cast_to_bool, is_csv, read_config
 from usansred.model import IQData, MonitorData, XYData
 from usansred.summary import generate_report
 
@@ -1010,7 +1010,7 @@ class Experiment(BaseModel):
         self.folder = os.path.dirname(self.config_file)
         self.config = read_config(self.config_file)
 
-        self.log_binning = bool(self.config["binning"]["log_binning"])
+        self.log_binning = cast_to_bool(self.config["binning"]["log_binning"])
 
         background = self.config["background"]
         if background is None:

--- a/src/usansred/reduce.py
+++ b/src/usansred/reduce.py
@@ -357,7 +357,7 @@ class Sample(BaseModel):
         if self.experiment.log_binning:
             self.data_log_binned = self.log_bin_data(data_scaled)
 
-        if not self.is_background:
+        if self.experiment.background and not self.is_background:
             self.subtract_background(self.experiment.background)
 
         logging.info(f"Data reduction finished for sample {self.name}.")
@@ -421,12 +421,11 @@ class Sample(BaseModel):
             else:
                 stepmin = lq - testVal / 2.0
                 stepmax = lq + testVal / 2.0
-                origIdx = 0
+                origIdx = 1
                 while origIdx < len(iq_dict["Q"]):
-                    origIdx += 1
-                    # emulate the do-while loop
-                    if not ((iq_dict["Q"][origIdx] + fundamentalStep / 2.0) < stepmin):
+                    if (iq_dict["Q"][origIdx] + fundamentalStep / 2.0) >= stepmin:
                         break
+                    origIdx += 1
 
                 while origIdx < len(iq_dict["Q"]):
                     if (iq_dict["Q"][origIdx] - fundamentalStep / 2.0) <= stepmin:
@@ -491,8 +490,7 @@ class Sample(BaseModel):
                             logE[lIdx] += iq_dict["E"][origIdx] ** 2.0
 
                     origIdx += 1
-                    # emulate the do-while loop
-                    if not ((iq_dict["Q"][origIdx] - fundamentalStep / 2.0) < stepmax):
+                    if origIdx < len(iq_dict["Q"]) and (iq_dict["Q"][origIdx] - fundamentalStep / 2.0) >= stepmax:
                         break
 
         logI = [logI[ii] / logW[ii] for ii in range(numOfBins)]
@@ -1051,10 +1049,11 @@ class Experiment(BaseModel):
         if not os.path.exists(self.output_dir):
             os.makedirs(self.output_dir)
 
-        try:
-            self.background.reduce()
-        except Exception as e:  # noqa BLE001
-            logging.exception(f"Cannot reduce background {self.background.name}: {e}")
+        if self.background:
+            try:
+                self.background.reduce()
+            except Exception as e:  # noqa BLE001
+                logging.exception(f"Cannot reduce background {self.background.name}: {e}")
 
         for sample in self.samples:
             try:

--- a/src/usansred/reduce.py
+++ b/src/usansred/reduce.py
@@ -1,6 +1,5 @@
 import copy
 import csv
-import json
 import logging
 import math
 import os
@@ -355,7 +354,7 @@ class Sample(BaseModel):
         logging.info(f"Only the first bank data is used for sample {self.name}.")
 
         # Log-binning is optional
-        if self.experiment.logbin:
+        if self.experiment.log_binning:
             self.data_log_binned = self.log_bin_data(data_scaled)
 
         if not self.is_background:
@@ -381,7 +380,8 @@ class Sample(BaseModel):
         fundamentalStep = 2 * math.pi * horizontal_rocking_width(1) * ARCSEC_TO_RADIANS / self.experiment.prim_wave
 
         # Step multiplier
-        alpha = math.exp(math.log(10) / self.experiment.step_per_dec)
+        steps_per_decade = self.experiment.config["binning"]["steps_per_decade"]
+        alpha = math.exp(math.log(10) / steps_per_decade)
         # step relative width
         kappa = 2.0 * (alpha - 1) / (alpha + 1)
 
@@ -747,7 +747,7 @@ class Sample(BaseModel):
             Scaling factor for background intensity before subtraction.
         """
 
-        if self.experiment.logbin:
+        if self.experiment.log_binning:
             assert self.is_log_binned, f"Sample {self.name} must be log-binned before background subtraction."
             assert background.is_log_binned, (
                 f"Background {background.name} must be log-binned before background subtraction."
@@ -984,9 +984,7 @@ class Experiment(BaseModel):
         Vertical angle, default is 0.042
     min_q : float
         Minimum Q value for binning output, default is 1e-6
-    step_per_dec : int
-        Steps per decade in binning, default is 33
-    logbin : bool
+    log_binning : bool
         Flag for log-binning, default is False
     """
 
@@ -996,8 +994,7 @@ class Experiment(BaseModel):
     prim_wave: float = Field(3.6, description="Primary wavelength in Angstroms")
     v_angle: float = Field(0.042, description="Vertical angle")
     min_q: float = Field(1e-6, description="Minimum Q value for binning output")
-    step_per_dec: int = Field(33, description="Steps per decade in binning")
-    logbin: bool = Field(False, description="Flag for logbinning")
+    log_binning: bool = Field(False, description="Flag for log-binning")
     # Fields that are initialized in model_post_init and not expected from user input
     folder: str = Field(default="", init=False, description="Working folder for this experiment")
     num_of_banks: int = Field(default=4, init=False, description="Number of detector banks")
@@ -1020,19 +1017,23 @@ class Experiment(BaseModel):
             raise FileNotFoundError(f"The file path: {self.config_file} does not exist")
 
         self.folder = os.path.dirname(self.config_file)
-        self.config = {"save_all_harmonics": False}
+        self.config = read_config(self.config_file)
+        self.config.setdefault("save_all_harmonics", False)
+        binning_config = self.config.setdefault("binning", {})
+        binning_config.setdefault("log_binning", self.log_binning)
+        binning_config.setdefault("steps_per_decade", 33)
 
         _, extension = os.path.splitext(self.config_file)
         if extension.lower() == ".json":
-            with open(self.config_file, "r") as f:
-                self.config.update(json.load(f))
-            if self.logbin:  # command line option --logbin overrides the JSON options
-                self.config["log_binning"] = True
+            if self.log_binning:  # command line option --logbin overrides the JSON options
+                binning_config["log_binning"] = True
             else:
-                self.logbin = bool(self.config.get("log_binning", False))
-        config = read_config(self.config_file)
-        background = config["background"]
-        samples = config["samples"]
+                self.log_binning = bool(binning_config.get("log_binning", False))
+        else:
+            binning_config["log_binning"] = self.log_binning
+
+        background = self.config["background"]
+        samples = self.config["samples"]
         if background is None:
             logging.warning("No background sample defined in the configuration file.")
             self.background = None
@@ -1091,7 +1092,7 @@ def parse_args():
 def main():
     """Main function to run USANS data reduction"""
     args = parse_args()
-    experiment = Experiment(config_file=args.path, logbin=args.logbin, output_dir=args.output)
+    experiment = Experiment(config_file=args.path, log_binning=args.logbin, output_dir=args.output)
     experiment.reduce()
     generate_report(config_file_path=args.path, output_dir=experiment.output_dir)
 

--- a/src/usansred/reduce.py
+++ b/src/usansred/reduce.py
@@ -10,7 +10,7 @@ import numpy as np
 from pydantic import BaseModel, Field
 from scipy.optimize import curve_fit, differential_evolution
 
-from usansred.io.read import read_config
+from usansred.io.read import is_csv, read_config
 from usansred.model import IQData, MonitorData, XYData
 from usansred.summary import generate_report
 
@@ -386,9 +386,10 @@ class Sample(BaseModel):
         kappa = 2.0 * (alpha - 1) / (alpha + 1)
 
         # floor ((ln((MyQ[InLength-1])/Qmin))/(ln(alpha)))
-        numOfBins = math.floor(math.log(max(iq_dict["Q"]) / self.experiment.min_q) / math.log(alpha))
+        q_min = self.experiment.config["binning"]["q_min"]
+        numOfBins = math.floor(math.log(max(iq_dict["Q"]) / q_min) / math.log(alpha))
 
-        logQ = [self.experiment.min_q * (alpha**n) for n in range(numOfBins)]
+        logQ = [q_min * (alpha**n) for n in range(numOfBins)]
         logI = [None] * numOfBins
         logE = [None] * numOfBins
         logW = [1] * numOfBins
@@ -982,8 +983,6 @@ class Experiment(BaseModel):
         Primary wavelength in Angstroms, default is 3.6
     v_angle : float
         Vertical angle, default is 0.042
-    min_q : float
-        Minimum Q value for binning output, default is 1e-6
     log_binning : bool
         Flag for log-binning, default is False
     """
@@ -993,11 +992,9 @@ class Experiment(BaseModel):
     output_dir: str = Field("", description="Output folder for reduced data")
     prim_wave: float = Field(3.6, description="Primary wavelength in Angstroms")
     v_angle: float = Field(0.042, description="Vertical angle")
-    min_q: float = Field(1e-6, description="Minimum Q value for binning output")
     log_binning: bool = Field(False, description="Flag for log-binning")
-    # Fields that are initialized in model_post_init and not expected from user input
-    folder: str = Field(default="", init=False, description="Working folder for this experiment")
     num_of_banks: int = Field(default=4, init=False, description="Number of detector banks")
+    folder: str = Field(default="", init=False, description="Working folder for this experiment")
     background: "Sample | None" = Field(default=None, init=False, description="Background sample")
     samples: list["Sample"] = Field(default_factory=list, init=False, description="List of samples")
 
@@ -1018,28 +1015,32 @@ class Experiment(BaseModel):
 
         self.folder = os.path.dirname(self.config_file)
         self.config = read_config(self.config_file)
-        self.config.setdefault("save_all_harmonics", False)
-        binning_config = self.config.setdefault("binning", {})
-        binning_config.setdefault("log_binning", self.log_binning)
-        binning_config.setdefault("steps_per_decade", 33)
 
-        _, extension = os.path.splitext(self.config_file)
-        if extension.lower() == ".json":
-            if self.log_binning:  # command line option --logbin overrides the JSON options
-                binning_config["log_binning"] = True
-            else:
-                self.log_binning = bool(binning_config.get("log_binning", False))
-        else:
-            binning_config["log_binning"] = self.log_binning
+        self.log_binning = bool(self.config["binning"]["log_binning"])
 
         background = self.config["background"]
-        samples = self.config["samples"]
         if background is None:
-            logging.warning("No background sample defined in the configuration file.")
+            logging.info("No background sample defined in the configuration file.")
             self.background = None
         else:
             self.background = Sample(**background, experiment=self)
-        self.samples = [Sample(**s, experiment=self) for s in samples]
+
+        self.samples = [Sample(**s, experiment=self) for s in self.config["samples"]]
+
+    def amend_log_binning(self, logbin: bool) -> None:
+        """Override the log-binning setting with the command-line --logbin flag.
+
+        For backwards compatibility when user enters a CSV file
+
+        Parameters
+        ----------
+        logbin : bool
+            When True, enables log-binning regardless of what the config file says.
+            When False, the config-file value set during initialisation is preserved.
+        """
+        if logbin:
+            self.log_binning = True
+            self.config["binning"]["log_binning"] = True
 
     def reduce(self, output_dir: str | None = None):
         """Reduce the USANS data
@@ -1092,7 +1093,9 @@ def parse_args():
 def main():
     """Main function to run USANS data reduction"""
     args = parse_args()
-    experiment = Experiment(config_file=args.path, log_binning=args.logbin, output_dir=args.output)
+    experiment = Experiment(config_file=args.path, output_dir=args.output)
+    if is_csv(args.path):  # backwards compatibility for CSV files, which don't have log-binning settings
+        experiment.amend_log_binning(args.logbin)
     experiment.reduce()
     generate_report(config_file_path=args.path, output_dir=experiment.output_dir)
 

--- a/src/usansred/reduce.py
+++ b/src/usansred/reduce.py
@@ -535,7 +535,6 @@ class Sample(BaseModel):
     def rescale_data(self) -> None:
         """Rescale reflected data by the analyzer's solid angle acceptance and by sample thickness."""
 
-
         assert self.size > 0, "No data points to rescale. Please check if the scans have been stitched correctly."
 
         self.data_scaled = []

--- a/src/usansred/reduce.py
+++ b/src/usansred/reduce.py
@@ -21,7 +21,36 @@ console = logging.StreamHandler()
 console.setLevel(logging.INFO)
 logging.getLogger("").addHandler(console)
 
-DARWIN_WIDTH = 5.1  # Darwin width, shouldn't really ever change unless instrument is disassembled
+
+ARCSEC_TO_RADIANS = math.pi / (3600.0 * 180.0)
+
+
+def _gaussian(x: np.ndarray, background: float, amplitude: float, sigma: float, center: float) -> np.ndarray:
+    """Gaussian peak with arbitrary amplitude on a constant background."""
+    return background + amplitude * np.exp(-0.5 * ((x - center) / sigma) ** 2.0)
+
+
+def horizontal_rocking_width(order: int) -> float:
+    """
+    FWHM (arcs) of the resolution function at the detector for a given reflection order
+
+    References
+    ----------
+    M. Agamalian et al., "Progress on The Time-of-Flight Ultra Small Angle Neutron Scattering Instrument at SNS",
+    J. Phys.: Conf. Ser. 1021 (2018) 012033.
+
+    Parameters
+    ----------
+    order : int
+        Positive reflection order (a.k.a. harmonic or bank)
+
+    Returns
+    -------
+    float
+        Computed horizontal angular resolution.
+    """
+    assert order > 0, "Order must be positive"
+    return 5.34 * math.exp(-0.01793 * order**2) / order**2
 
 
 class Scan(BaseModel):
@@ -120,6 +149,31 @@ class Scan(BaseModel):
         )
         return iq_data
 
+    def normalize_by_monitor(self) -> None:
+        """Normalize detector intensities by monitor counts.
+
+        Each harmonic in the scan is normalized independently, and within each harmonic,
+        the counts collected at the detector during the time the analyzer-motor remained at a particular angle
+        are divided by the counts collected at the monitor during such time.
+        """
+        for harmonic in self.detector_data:
+            intensity_normalized = []
+            error_normalized = []
+
+            for monitor_i, monitor_e, detector_i, detector_e in zip(
+                self.monitor_data.iq_data.i,
+                self.monitor_data.iq_data.e,
+                harmonic.iq_data.i,
+                harmonic.iq_data.e,
+            ):
+                intensity = detector_i / monitor_i
+                error = np.sqrt(detector_e**2 + (intensity * monitor_e) ** 2) / monitor_i
+                intensity_normalized.append(intensity)
+                error_normalized.append(error)
+
+            harmonic.iq_data.i = intensity_normalized
+            harmonic.iq_data.e = error_normalized
+
 
 class Sample(BaseModel):
     """Container for sample information, related scans, and data reduction methods"""
@@ -151,7 +205,7 @@ class Sample(BaseModel):
         self.num_of_scans = len(self.scans)
 
         # NOTE:
-        #  - detector_data: original data after being stitched with another scan
+        #  - detector_data: original data after being stitched with another monitor-normalized scan
         #  - data_scaled: data after being scaled to thickness
         #  - data_log_binned: data_scaled after being log-binned
         #  - data_bg_subtracted: data_log_binned after background subtraction (aliased as self.data_reduced)
@@ -261,6 +315,15 @@ class Sample(BaseModel):
         if scaled_data:
             filepath = os.path.join(self.experiment.output_dir, f"UN_{self.name}_det_1.txt")
             self.dump_data_to_csv(filepath, self.data_scaled[0])
+            if self.config.get("save_all_harmonics", False):
+                for i in range(1, self.num_of_banks):
+                    bank = i + 1  # start with the second order
+                    filepath = os.path.join(
+                        self.experiment.output_dir,
+                        f"bank_{bank}",
+                        f"UN_{self.name}.txt",
+                    )
+                    self.dump_data_to_csv(filepath, self.data_scaled[i])
 
         if bg_subtracted_data:
             filepath = os.path.join(self.experiment.output_dir, f"UN_{self.name}_det_1_lbs.txt")
@@ -275,9 +338,16 @@ class Sample(BaseModel):
 
         return
 
+    def normalize_by_monitor(self) -> None:
+        """Normalize detector intensities by monitor counts for all scans."""
+        for scan in self.scans:
+            scan.normalize_by_monitor()
+
     def reduce(self):
         """Reduce this sample's scans"""
-        self.stitch_data()
+        self.normalize_by_monitor()
+        self.stitch_scans()
+        self.rocking_curve_centering()
         self.rescale_data()
 
         # Only process first detector bank
@@ -286,9 +356,7 @@ class Sample(BaseModel):
 
         # Log-binning is optional
         if self.experiment.logbin:
-            self.data_log_binned.q, self.data_log_binned.i, self.data_log_binned.e = self.log_bin_data(
-                data_scaled.q, data_scaled.i, data_scaled.e
-            )
+            self.data_log_binned = self.log_bin_data(data_scaled)
 
         if not self.is_background:
             self.subtract_background(self.experiment.background)
@@ -297,25 +365,20 @@ class Sample(BaseModel):
         return
 
     # TODO: This function should be re-written from scratch
-    def log_bin_data(
-        self, momentum_transfer: list[float], intensity: list[float], error: list[float]
-    ) -> tuple[list[float], list[float], list[float]]:
+    def log_bin_data(self, data: IQData) -> IQData:
         """Log-bin the I(Q) data."""
-        assert len(momentum_transfer) == len(intensity) == len(error)
+        assert len(data.q) == len(data.i) == len(data.e)
 
         # Sort by momentum transfer
-        sorted_indices = np.argsort(momentum_transfer)
-        momentum_transfer = np.array(momentum_transfer)[sorted_indices]
-        intensity = np.array(intensity)[sorted_indices]
-        error = np.array(error)[sorted_indices]
+        sorted_indices = np.argsort(data.q)
+        q = np.array(data.q)[sorted_indices]
+        i = np.array(data.i)[sorted_indices]
+        e = np.array(data.e)[sorted_indices]
 
-        data = {"I": list(intensity), "Q": list(momentum_transfer), "E": list(error)}
+        iq_dict = {"I": list(i), "Q": list(q), "E": list(e)}
 
-        # The fundamental Q width of the measurement
-        harNo = 1.0  # Only the first harmonic peak is used
-        fundamentalStep = (
-            2 * math.pi**2 * self.experiment.darwin_width * harNo / (self.experiment.prim_wave * 3600.0 * 180.0)
-        )
+        # The resolution in Q, ΔQ=2πΔθ/λ_1, where Δθ is the FWHM of the resolution function at the detector
+        fundamentalStep = 2 * math.pi * horizontal_rocking_width(1) * ARCSEC_TO_RADIANS / self.experiment.prim_wave
 
         # Step multiplier
         alpha = math.exp(math.log(10) / self.experiment.step_per_dec)
@@ -323,9 +386,9 @@ class Sample(BaseModel):
         kappa = 2.0 * (alpha - 1) / (alpha + 1)
 
         # floor ((ln((MyQ[InLength-1])/Qmin))/(ln(alpha)))
-        numOfBins = math.floor(math.log(max(data["Q"]) / self.experiment.min_q) / math.log(alpha))
+        numOfBins = math.floor(math.log(max(iq_dict["Q"]) / self.experiment.min_q) / math.log(alpha))
 
-        logQ = [self.experiment.min_q * (alpha**i) for i in range(numOfBins)]
+        logQ = [self.experiment.min_q * (alpha**n) for n in range(numOfBins)]
         logI = [None] * numOfBins
         logE = [None] * numOfBins
         logW = [1] * numOfBins
@@ -343,14 +406,14 @@ class Sample(BaseModel):
 
             if testVal <= fundamentalStep:
                 while logI[lIdx] is None:
-                    if origIdx < (len(data["Q"]) - 1) and data["Q"][origIdx + 1] > lq:
-                        k2 = data["Q"][origIdx + 1] - data["Q"][origIdx]
-                        k3 = lq - data["Q"][origIdx + 1]
+                    if origIdx < (len(iq_dict["Q"]) - 1) and iq_dict["Q"][origIdx + 1] > lq:
+                        k2 = iq_dict["Q"][origIdx + 1] - iq_dict["Q"][origIdx]
+                        k3 = lq - iq_dict["Q"][origIdx + 1]
                         # rtemp[outindex]=((k3/k2)+1)*MyR[inindex+1]-(k3/k2)*MyR[inindex]
-                        logI[lIdx] = ((k3 / k2) + 1) * data["I"][origIdx + 1] - (k3 / k2) * data["I"][origIdx]
-                        logE[lIdx] = (((k3 / k2) + 1) ** 2.0) * (data["E"][origIdx + 1] ** 2.0) + ((k3 / k2) ** 2.0) * (
-                            data["E"][origIdx] ** 2.0
-                        )
+                        logI[lIdx] = ((k3 / k2) + 1) * iq_dict["I"][origIdx + 1] - (k3 / k2) * iq_dict["I"][origIdx]
+                        logE[lIdx] = (((k3 / k2) + 1) ** 2.0) * (iq_dict["E"][origIdx + 1] ** 2.0) + (
+                            (k3 / k2) ** 2.0
+                        ) * (iq_dict["E"][origIdx] ** 2.0)
                         logW[lIdx] = 1
                     else:
                         origIdx += 1
@@ -358,241 +421,163 @@ class Sample(BaseModel):
                 stepmin = lq - testVal / 2.0
                 stepmax = lq + testVal / 2.0
                 origIdx = 0
-                while origIdx < len(data["Q"]):
+                while origIdx < len(iq_dict["Q"]):
                     origIdx += 1
                     # emulate the do-while loop
-                    if not ((data["Q"][origIdx] + fundamentalStep / 2.0) < stepmin):
+                    if not ((iq_dict["Q"][origIdx] + fundamentalStep / 2.0) < stepmin):
                         break
 
-                while origIdx < len(data["Q"]):
-                    if (data["Q"][origIdx] - fundamentalStep / 2.0) <= stepmin:
+                while origIdx < len(iq_dict["Q"]):
+                    if (iq_dict["Q"][origIdx] - fundamentalStep / 2.0) <= stepmin:
                         if logI[lIdx] is None:
                             # rtemp[outindex]=MyR[Inindex]*((MyQ[inindex]+FunStep/2)-stepmin)/funstep
                             # wtemp[outindex]=(MyQ[inindex]+FunStep/2-stepmin)/funstep
                             # stemp[outindex]=(MyS[InIndex]^2)*((MyQ[inindex]+FunStep/2-stepmin)/funstep)^2
                             logI[lIdx] = (
-                                data["I"][origIdx]
-                                * ((data["Q"][origIdx] + fundamentalStep / 2.0) - stepmin)
+                                iq_dict["I"][origIdx]
+                                * ((iq_dict["Q"][origIdx] + fundamentalStep / 2.0) - stepmin)
                                 / fundamentalStep
                             )
-                            logW[lIdx] = (data["Q"][origIdx] + fundamentalStep / 2.0 - stepmin) / fundamentalStep
-                            logE[lIdx] = (data["E"][origIdx] ** 2.0) * (
-                                (data["Q"][origIdx] + fundamentalStep / 2.0 - stepmin) / fundamentalStep
+                            logW[lIdx] = (iq_dict["Q"][origIdx] + fundamentalStep / 2.0 - stepmin) / fundamentalStep
+                            logE[lIdx] = (iq_dict["E"][origIdx] ** 2.0) * (
+                                (iq_dict["Q"][origIdx] + fundamentalStep / 2.0 - stepmin) / fundamentalStep
                             ) ** 2.0
                         else:
                             # rtemp[outindex]+=MyR[Inindex]*((MyQ[inindex]+FunStep/2)-stepmin)/funstep
                             # wtemp[outindex]+=(MyQ[inindex]+FunStep/2-stepmin)/funstep
                             # stemp[outindex]+=(MyS[InIndex]^2)*((MyQ[inindex]+FunStep/2-stepmin)/funstep)^2
                             logI[lIdx] += (
-                                data["I"][origIdx]
-                                * ((data["Q"][origIdx] + fundamentalStep / 2.0) - stepmin)
+                                iq_dict["I"][origIdx]
+                                * ((iq_dict["Q"][origIdx] + fundamentalStep / 2.0) - stepmin)
                                 / fundamentalStep
                             )
-                            logW[lIdx] += (data["Q"][origIdx] + fundamentalStep / 2.0 - stepmin) / fundamentalStep
-                            logE[lIdx] += (data["E"][origIdx] ** 2.0) * (
-                                (data["Q"][origIdx] + fundamentalStep / 2.0 - stepmin) / fundamentalStep
+                            logW[lIdx] += (iq_dict["Q"][origIdx] + fundamentalStep / 2.0 - stepmin) / fundamentalStep
+                            logE[lIdx] += (iq_dict["E"][origIdx] ** 2.0) * (
+                                (iq_dict["Q"][origIdx] + fundamentalStep / 2.0 - stepmin) / fundamentalStep
                             ) ** 2.0
-                    elif (self.data["Q"][origIdx] + fundamentalStep / 2.0) > stepmax:
+                    elif (iq_dict["Q"][origIdx] + fundamentalStep / 2.0) > stepmax:
                         if logI[lIdx] is None:
                             # rtemp[outindex]=MyR[Inindex]*(stepmax-(MyQ[inindex]-FunStep/2))/funstep
                             # wtemp[outindex]=(stepmax-(MyQ[inindex]-FunStep/2))/funstep
                             # stemp[outindex]=(MyS[InIndex]^2)*((stepmax-(MyQ[inindex]-FunStep/2))/funstep)^2
                             logI[lIdx] = (
-                                data["I"][origIdx]
-                                * (stepmax - (data["Q"][origIdx] - fundamentalStep / 2.0))
+                                iq_dict["I"][origIdx]
+                                * (stepmax - (iq_dict["Q"][origIdx] - fundamentalStep / 2.0))
                                 / fundamentalStep
                             )
-                            logW[lIdx] = (stepmax - (data["Q"][origIdx] - fundamentalStep / 2.0)) / fundamentalStep
-                            logE[lIdx] = (data["E"][origIdx] ** 2.0) * (
-                                (stepmax - (data["Q"][origIdx] - fundamentalStep / 2.0)) / fundamentalStep
+                            logW[lIdx] = (stepmax - (iq_dict["Q"][origIdx] - fundamentalStep / 2.0)) / fundamentalStep
+                            logE[lIdx] = (iq_dict["E"][origIdx] ** 2.0) * (
+                                (stepmax - (iq_dict["Q"][origIdx] - fundamentalStep / 2.0)) / fundamentalStep
                             ) ** 2.0
                         else:
                             logI[lIdx] += (
-                                data["I"][origIdx]
-                                * (stepmax - (data["Q"][origIdx] - fundamentalStep / 2.0))
+                                iq_dict["I"][origIdx]
+                                * (stepmax - (iq_dict["Q"][origIdx] - fundamentalStep / 2.0))
                                 / fundamentalStep
                             )
-                            logW[lIdx] += (
-                                stepmax - (self.data["Q"][origIdx] - fundamentalStep / 2.0)
-                            ) / fundamentalStep
-                            logE[lIdx] += (data["E"][origIdx] ** 2.0) * (
-                                (stepmax - (data["Q"][origIdx] - fundamentalStep / 2.0)) / fundamentalStep
+                            logW[lIdx] += (stepmax - (iq_dict["Q"][origIdx] - fundamentalStep / 2.0)) / fundamentalStep
+                            logE[lIdx] += (iq_dict["E"][origIdx] ** 2.0) * (
+                                (stepmax - (iq_dict["Q"][origIdx] - fundamentalStep / 2.0)) / fundamentalStep
                             ) ** 2.0
                     else:
                         if logI[lIdx] is None:
-                            logI[lIdx] = data["I"][origIdx]
+                            logI[lIdx] = iq_dict["I"][origIdx]
                             logW[lIdx] = 1.0
-                            logE[lIdx] = data["E"][origIdx] ** 2.0
+                            logE[lIdx] = iq_dict["E"][origIdx] ** 2.0
                         else:
-                            logI[lIdx] += data["I"][origIdx]
+                            logI[lIdx] += iq_dict["I"][origIdx]
                             logW[lIdx] += 1.0
-                            logE[lIdx] += data["E"][origIdx] ** 2.0
+                            logE[lIdx] += iq_dict["E"][origIdx] ** 2.0
 
                     origIdx += 1
                     # emulate the do-while loop
-                    if not ((data["Q"][origIdx] - fundamentalStep / 2.0) < stepmax):
+                    if not ((iq_dict["Q"][origIdx] - fundamentalStep / 2.0) < stepmax):
                         break
 
         logI = [logI[ii] / logW[ii] for ii in range(numOfBins)]
         logE = [logE[ii] / (logW[ii] ** 2.0) for ii in range(numOfBins)]
         logE = [le**0.5 for le in logE]
 
-        return (logQ, logI, logE)
+        return IQData(q=logQ, i=logI, e=logE)
 
-    def rescale_data(self, guess_init: bool = False) -> None:
-        """Rescale data with thickness.
-        Fit the I(Q) data to gaussian and calculate peak area.
+    @staticmethod
+    def _combine_duplicate_q_points(
+        q_scaled: list[float], i_scaled: list[float], e_scaled: list[float]
+    ) -> tuple[list[float], list[float], list[float]]:
+        """Sort by Q and average duplicate momentum transfer points.
 
-        For higher order harmonics, the peak area is estimated from the relative integrated rocking-curve areas
-        (M. Agamalian et al., "Progress on The Time-of-Flight Ultra Small Angle Neutron Scattering Instrument at SNS",
-        J. Phys.: Conf. Ser. 1021 (2018) 012033)
-
-        Parameters
-        ----------
-        guess_init : bool
-            Whether to guess initial parameters for fitting with differential_evolution.
+        Duplicate Q values happen when negative and positive analyzer-motor angles
+        have the same magnitude after conversion to momentum transfer in 1/angstrom.
+        Intensities are averaged, and uncertainties are propagated for the averaged
+        values.
         """
+        # Dictionary to store sums for averaging I and propagating errors for E.
+        # One dictionary entry per unique Q value, which is itself a dictionary.
+        sum_dict = defaultdict(lambda: {"I_sum": 0, "I_count": 0, "E_sum_squares": 0})
 
-        # ratio of integrated rocking-curve areas for higher order harmonics relative to the first harmonic
-        # Si(220), Bragg-angle 69.9 degrees
-        peak_area_ratio = [
-            1.0,  # n = 1, lambda = 3.60 A
-            0.131,  # n = 2, lambda = 1.80 A
-            0.081,  # n = 3, lambda = 1.20 A
-            0.0166,  # n = 4, lambda = 0.90 A
-            0.0093,  # n = 5, lambda = 0.72 A
-            0.00106,  # n = 6, lambda = 0.60 A
-        ]
+        for q, i, e in zip(q_scaled, i_scaled, e_scaled):
+            sum_dict[q]["I_sum"] += i
+            sum_dict[q]["I_count"] += 1
+            sum_dict[q]["E_sum_squares"] += e**2
 
-        def _gaussian(x: np.ndarray, k0: float, k1: float, k2: float) -> np.ndarray:
-            """The Gaussian equation according to Igor definition of gaussian curvefit.
+        q_cleaned = []
+        i_cleaned = []
+        e_cleaned = []
 
-            https://www.wavemetrics.net/doc/igorman/V-01%20Reference.pdf
-            """
-            return k0 + 1.0 / (k1 * np.sqrt(2 * math.pi)) * np.exp(-1.0 / 2.0 * ((x - k2) / k1) ** 2.0)
+        for q, values in sorted(sum_dict.items()):
+            q_cleaned.append(q)
+            i_cleaned.append(values["I_sum"] / values["I_count"])
+            e_cleaned.append(math.sqrt(values["E_sum_squares"]) / values["I_count"])
 
-        def _sum_of_squared_error(params: tuple[float, float, float]) -> float:
-            """Function for genetic algorithm to minimize."""
-            k0, k1, k2 = params
-            val = _gaussian(np.array(self.data.q), k0, k1, k2)
-            result = np.sum((np.array(self.data.i) - val) ** 2)
-            return result
+        return q_cleaned, i_cleaned, e_cleaned
 
-        def _generate_initial_parameters(test_x: np.ndarray, test_y: np.ndarray):
-            max_x = max(test_x)
-            max_y = max(test_y)
-            max_xy = max(max_x, max_y)
+    def rescale_data(self) -> None:
+        """Rescale reflected data by the analyzer's solid angle acceptance and by sample thickness."""
 
-            parameter_bounds = [
-                [-max_xy, max_xy],  # k0
-                [-max_xy, max_xy],  # k1
-                [-max_xy, max_xy],  # k2
-            ]
+        # DEBUG: temporary save
+        columns = [self.data.q] + [iq.i for iq in self.detector_data]
+        np.savetxt(f"/tmp/stiched_{self.scans[0].number}.dat", np.column_stack(columns), delimiter="  ", fmt="%.6e")
 
-            # "seed" the numpy random number generator for repeatable results
-            result = differential_evolution(_sum_of_squared_error, parameter_bounds, seed=3)
+        assert self.size > 0, "No data points to rescale. Please check if the scans have been stitched correctly."
 
-            return result.x
+        self.data_scaled = []
 
-        def _clean_iq(q_scaled: list[float], i_scaled: list[float], e_scaled: list[float]):
-            """Remove duplicate values in q by:
-            - Taking the average of all i-values with the same q
-            - Taking the standard deviation of all e-values with the same q
-            """
-            # Dictionary to store sums for averaging I and propagating errors for E
-            sum_dict = defaultdict(lambda: {"I_sum": 0, "I_count": 0, "E_sum_squares": 0})
+        for harmonic in range(1, 1 + self.num_of_banks):
+            # angle-to-Q conversion factor: radians_per_arcsecond * (2π / λ_n)
+            theta_to_q = ARCSEC_TO_RADIANS * (2 * math.pi / (self.experiment.prim_wave / harmonic))
 
-            for q, i, e in zip(q_scaled, i_scaled, e_scaled):
-                sum_dict[q]["I_sum"] += i
-                sum_dict[q]["I_count"] += 1
-                sum_dict[q]["E_sum_squares"] += e**2
+            # analyzer solid angle acceptance ΔΩ = vertical angular width * horizontal angular width
+            analyzer_solid_angle = self.experiment.v_angle * (horizontal_rocking_width(harmonic) * ARCSEC_TO_RADIANS)
 
-            q_cleaned = []
-            i_cleaned = []
-            e_cleaned = []
+            # negative theta angles do correspond to positive values of the momentum transfer, hence abs()
+            iq_data = self.detector_data[harmonic - 1]
+            q_scaled = [abs(theta) * theta_to_q for theta in iq_data.q]
+            scaling_factor = 1.0 / (analyzer_solid_angle * self.thickness)
+            i_scaled = [i * scaling_factor for i in iq_data.i]
+            e_scaled = [e * scaling_factor for e in iq_data.e]
 
-            for q, values in sum_dict.items():
-                q_cleaned.append(q)
-                i_cleaned.append(values["I_sum"] / values["I_count"])
-                e_cleaned.append(math.sqrt(values["E_sum_squares"]))
-
-            return q_cleaned, i_cleaned, e_cleaned
-
-        assert self.size > 0
-
-        initial_vals = [3.8e-6, 0.1, 0.8]
-        peak_area = None
-        q_offset = None
-
-        for b in range(self.num_of_banks):
-            bank = b + 1
-
-            # (2π / λ_n) * radians_per_arcsecond -- angle-to-Q conversion factor
-            h_scale = 2 * (math.pi**2.0) * bank / (self.experiment.prim_wave * 3600.0 * 180.0)
-
-            # harmonic-dependent horizontal angular width, converted from arcseconds to radians
-            horizontal_rocking_width = self.experiment.darwin_width / bank * math.pi / (3600.0 * 180.0)
-
-            # analyzer solid angle ΔΩ = vertical angular width * horizontal angular width
-            analyzer_solid_angle = self.experiment.v_angle * horizontal_rocking_width
-
-            # analyzer solid angle ΔΩ * sample thickness
-            v_scale = analyzer_solid_angle * self.thickness
-
-            if guess_init:
-                initial_vals = _generate_initial_parameters(np.array(self.data.q), np.array(self.data.i))
-
-            best_vals, sigma = curve_fit(
-                _gaussian,
-                np.array(self.data.q),
-                np.array(self.data.i),
-                p0=initial_vals,
-                sigma=self.data.e,
-                maxfev=100000,
-            )
-
-            initial_vals = list(best_vals)
-            peak_area = (
-                1.0
-                / (initial_vals[1] * math.sqrt(2 * math.pi))
-                * initial_vals[1]
-                * math.sqrt(2.0)
-                / math.sqrt(2 * math.pi)
-                / peak_area_ratio[b]
-            )
-            dar_test = initial_vals[1] * math.sqrt(2.0) * (math.pi) ** 0.5 * bank / self.experiment.darwin_width
-
-            if dar_test <= 0.13:
-                q_offset = initial_vals[2]
-            else:
-                q_offset = 0.0
-
-            q_scaled = [math.fabs((q - q_offset) * h_scale) for q in self.data.q]
-            i_scaled = [i / (v_scale * peak_area) for i in self.data.i]
-            e_scaled = [e / (v_scale * peak_area) for e in self.data.e]
-
-            q_cleaned, i_cleaned, e_cleaned = _clean_iq(q_scaled, i_scaled, e_scaled)
+            q_cleaned, i_cleaned, e_cleaned = self._combine_duplicate_q_points(q_scaled, i_scaled, e_scaled)
             iq_scaled = IQData(q=q_cleaned, i=i_cleaned, e=e_cleaned, t=[])
-
             self.data_scaled.append(iq_scaled)
 
         q_range = f"{min(self.data_scaled[0].q)} - {max(self.data_scaled[0].q)}"
         logging.info(f"Rescaled data for sample {self.name}, Q-range: {q_range} 1/angstrom\n")
         return
 
-    def stitch_data(self):
+    def stitch_scans(self):
         """Stitch scan data from each detector bank into per-bank intensity curves.
 
         For each detector bank (harmonic), combine all scans in ``self.scans`` onto a single
-        Intensity-versus-Q profile. The Q values are taken from the monitor data
-        and assumed to correspond to thew Q values from the detector data.
-        Detector intensities and errors are normalized by the corresponding monitor intensity
-        before being added to the stitched output.
+        Intensity-versus-Q profile. Detector intensities and errors are expected to
+        already be normalized by ``Scan.normalize_by_monitor`` before being added
+        to the stitched output.
 
-        If two or more scans contain the same Q value, their normalized intensities
-        are combined into one point using the existing variance-based weighting
-        formula, and the combined uncertainty is stored as the square root of the
-        summed variance.
+        Notice that at this stage, the "Q" values are actually analyzer-motor angles,
+        that is, detector bank ``iq_data.q`` values are analyzer-motor angles (in arcsec units).
+
+        If two or more scans contain the same "Q" value, their intensities are combined
+        into one point using the existing variance-based weighting formula, and the
+        combined uncertainty is stored as the square root of the summed variance.
 
         After all scans for a bank are processed, the stitched points are sorted by Q
 
@@ -608,44 +593,27 @@ class Sample(BaseModel):
             # transmission = []  # omitted for now
 
             for scan in self.scans:
-                # Pair the scan Q axis and monitor counts with this bank's detector counts.
                 scan_data = zip(
-                    scan.monitor_data.iq_data.q,
-                    scan.monitor_data.iq_data.i,
-                    scan.monitor_data.iq_data.e,
+                    scan.detector_data[bank].iq_data.q,
                     scan.detector_data[bank].iq_data.i,
                     scan.detector_data[bank].iq_data.e,
                 )
 
-                for (
-                    scan_q,
-                    monitor_intensity,
-                    monitor_error,
-                    detector_intensity,
-                    detector_error,
-                ) in scan_data:
-                    # Normalize detector counts and uncertainty by monitor counts.
-                    normalized_intensity = detector_intensity / monitor_intensity
-                    # Error propagation for a/b: σ = (a/b)*sqrt((σ_a/a)² + (σ_b/b)²)
-                    # Equivalent form avoids dividing by detector_intensity when it is zero.
-                    normalized_error = (
-                        np.sqrt(detector_error**2 + (normalized_intensity * monitor_error) ** 2) / monitor_intensity
-                    )
-
+                for scan_q, detector_intensity, detector_error in scan_data:
                     if scan_q in momentum_transfer:
                         # Merge repeated Q values from multiple scans into one stitched point.
                         matched_q_index = momentum_transfer.index(scan_q)
-                        combined_variance = error[matched_q_index] ** 2 + normalized_error**2
+                        combined_variance = error[matched_q_index] ** 2 + detector_error**2
                         intensity[matched_q_index] = (
                             intensity[matched_q_index] * (error[matched_q_index] ** 2)
-                            + normalized_intensity * normalized_error**2
+                            + detector_intensity * detector_error**2
                         ) / combined_variance
                         error[matched_q_index] = combined_variance**0.5
                     else:
                         # Add Q values that have not appeared in earlier scans.
                         momentum_transfer.append(scan_q)
-                        intensity.append(normalized_intensity)
-                        error.append(normalized_error)
+                        intensity.append(detector_intensity)
+                        error.append(detector_error)
 
             # Sort by momentum transfer (outside the scan loop, inside the bank loop)
             sorted_indices = np.argsort(momentum_transfer)
@@ -663,21 +631,82 @@ class Sample(BaseModel):
             )
         logging.info(f"Scans stitched together for sample {self.name}.\n")
 
-        h_scale = 2 * (math.pi**2.0) * 1.0 / (self.experiment.prim_wave * 3600.0 * 180.0)
+        theta_to_q = 2 * (math.pi**2.0) * 1.0 / (self.experiment.prim_wave * 3600.0 * 180.0)
         theta_range_msg = ""
         q_range_msg = ""
 
-        # Log raw theta ranges and converted Q ranges for each scan.
+        # Log raw theta ranges and converted Q ranges for each scan. Remember at this stage in the reduction,
+        # scan.detector_data[0].iq_data.q stores analyzer-motor angles, not yet converted to Q values
         for scan in self.scans:
-            q_range = f"{min(scan.detector_data[0].iq_data.q)} - {max(scan.detector_data[0].iq_data.q)}"
-            theta_range_msg += f"Theta range for scan {scan.number}: {q_range}\n"
-
-            temp_q = [math.fabs(q * h_scale) for q in scan.detector_data[0].iq_data.q]
+            theta_range = f"{min(scan.detector_data[0].iq_data.q)} - {max(scan.detector_data[0].iq_data.q)}"
+            theta_range_msg += f"Theta range for scan {scan.number}: {theta_range}\n"
+            temp_q = [math.fabs(theta * theta_to_q) for theta in scan.detector_data[0].iq_data.q]
             q_range_msg += f"Q range for scan {scan.number}: {min(temp_q)} - {max(temp_q)} 1/angstrom\n"
 
         logging.info(theta_range_msg)
         logging.info(q_range_msg)
         return
+
+    def rocking_curve_centering(self) -> float:
+        """Center the stitched rocking curves by fitting a Gaussian peak to the rocking curve of the first harmonic.
+
+        Notice that the ``q`` values of the stitched rocking curves are analyzer motor angles at this
+        stage of reduction, not yet converted to Q values.
+        The first harmonic is fit to a Gaussian over the  mostly symmetric angle range ``[q_min, -q_min]``,
+        where ``q_min`` is the minimum analyzier motor angle. It will be a negative value.
+        The center of the fitted Gaussian represents the value of the analyzer motor angle at which
+        the analyzer reflects neutrons that have not been scattered by the sample. It should be very close to zero.
+
+        Returns
+        -------
+        float
+            Fitted first-harmonic motor-angle center.
+        """
+        assert self.detector_data, "Detector data must be stitched before centering."
+
+        first_harmonic_rocking_curve = self.detector_data[0]
+        if not first_harmonic_rocking_curve.q:
+            raise ValueError("Cannot center rocking curve because first-harmonic curve is empty.")
+
+        q = np.array(first_harmonic_rocking_curve.q)
+        intensity = np.array(first_harmonic_rocking_curve.i)
+        error = np.array(first_harmonic_rocking_curve.e)
+
+        q_min = float(np.min(q))
+        if q_min >= 0:
+            raise ValueError("Can't center rocking curve because angles don't include negative values.")
+
+        fit_mask = (q >= q_min) & (q <= -q_min)
+        q_fit = q[fit_mask]
+        intensity_fit = intensity[fit_mask]
+        error_fit = error[fit_mask] if len(error) == len(q) else None
+
+        if len(q_fit) < 3:
+            raise ValueError("Can't center rocking curve because fewer than three points are in the symmetric range.")
+
+        # Initial guess for Gaussian parameters: background, amplitude, sigma, center
+        initial_guess = {
+            "background": float(np.min(intensity_fit)),
+            "amplitude": float(np.max(intensity_fit) - np.min(intensity_fit)),
+            "sigma": float(max(np.std(q_fit), np.finfo(float).eps)),
+            "center": float(q_fit[np.argmax(intensity_fit)]),
+        }
+
+        best_vals, _sigma = curve_fit(
+            _gaussian,
+            q_fit,
+            intensity_fit,
+            p0=list(initial_guess.values()),
+            sigma=error_fit,
+            maxfev=100000,
+        )
+        q_offset = float(best_vals[3])  # the center of the fitted Gaussian
+
+        for rocking_curve in self.detector_data:
+            rocking_curve.q = [float(harmonic_q - q_offset) for harmonic_q in rocking_curve.q]
+
+        logging.info(f"Centered rocking curves for sample {self.name} using offset {q_offset}.")
+        return q_offset
 
     def _match_or_interpolate(
         self,
@@ -951,8 +980,6 @@ class Experiment(BaseModel):
         Output folder for reduced data, default is current folder
     prim_wave : float
         Primary wavelength in Angstroms, default is 3.6
-    darwin_width : float
-        Darwin width, default is 5.1
     v_angle : float
         Vertical angle, default is 0.042
     min_q : float
@@ -967,7 +994,6 @@ class Experiment(BaseModel):
     config: dict = Field(default_factory=dict, description="configuration file loaded into a Python dictionary")
     output_dir: str = Field("", description="Output folder for reduced data")
     prim_wave: float = Field(3.6, description="Primary wavelength in Angstroms")
-    darwin_width: float = Field(DARWIN_WIDTH, description="Darwin width")
     v_angle: float = Field(0.042, description="Vertical angle")
     min_q: float = Field(1e-6, description="Minimum Q value for binning output")
     step_per_dec: int = Field(33, description="Steps per decade in binning")
@@ -1000,6 +1026,10 @@ class Experiment(BaseModel):
         if extension.lower() == ".json":
             with open(self.config_file, "r") as f:
                 self.config.update(json.load(f))
+            if self.logbin:  # command line option --logbin overrides the JSON options
+                self.config["log_binning"] = True
+            else:
+                self.logbin = bool(self.config.get("log_binning", False))
         config = read_config(self.config_file)
         background = config["background"]
         samples = config["samples"]

--- a/src/usansred/reduce.py
+++ b/src/usansred/reduce.py
@@ -535,9 +535,6 @@ class Sample(BaseModel):
     def rescale_data(self) -> None:
         """Rescale reflected data by the analyzer's solid angle acceptance and by sample thickness."""
 
-        # DEBUG: temporary save
-        columns = [self.data.q] + [iq.i for iq in self.detector_data]
-        np.savetxt(f"/tmp/stiched_{self.scans[0].number}.dat", np.column_stack(columns), delimiter="  ", fmt="%.6e")
 
         assert self.size > 0, "No data points to rescale. Please check if the scans have been stitched correctly."
 

--- a/src/usansred/reduce.py
+++ b/src/usansred/reduce.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import numpy as np
 from pydantic import BaseModel, Field
-from scipy.optimize import curve_fit, differential_evolution
+from scipy.optimize import curve_fit
 
 from usansred.io.read import is_csv, read_config
 from usansred.model import IQData, MonitorData, XYData
@@ -573,8 +573,8 @@ class Sample(BaseModel):
         that is, detector bank ``iq_data.q`` values are analyzer-motor angles (in arcsec units).
 
         If two or more scans contain the same "Q" value, their intensities are combined
-        into one point using the existing variance-based weighting formula, and the
-        combined uncertainty is stored as the square root of the summed variance.
+        into one point using inverse-variance weighting, and the combined uncertainty
+        is stored as the square root of the inverse summed weights.
 
         After all scans for a bank are processed, the stitched points are sorted by Q
 
@@ -598,14 +598,15 @@ class Sample(BaseModel):
 
                 for scan_q, detector_intensity, detector_error in scan_data:
                     if scan_q in momentum_transfer:
-                        # Merge repeated Q values from multiple scans into one stitched point.
+                        # Merge repeated Q values from multiple scans using inverse-variance weights.
                         matched_q_index = momentum_transfer.index(scan_q)
-                        combined_variance = error[matched_q_index] ** 2 + detector_error**2
+                        matched_weight = 1.0 / error[matched_q_index] ** 2
+                        detector_weight = 1.0 / detector_error**2
+                        combined_weight = matched_weight + detector_weight
                         intensity[matched_q_index] = (
-                            intensity[matched_q_index] * (error[matched_q_index] ** 2)
-                            + detector_intensity * detector_error**2
-                        ) / combined_variance
-                        error[matched_q_index] = combined_variance**0.5
+                            intensity[matched_q_index] * matched_weight + detector_intensity * detector_weight
+                        ) / combined_weight
+                        error[matched_q_index] = (1.0 / combined_weight) ** 0.5
                     else:
                         # Add Q values that have not appeared in earlier scans.
                         momentum_transfer.append(scan_q)
@@ -971,8 +972,7 @@ class Experiment(BaseModel):
     config_file : str
         Path to the configuration file
     config : dict
-        Configuration file loaded into a Python dictionary. Populated only for
-        JSON config files; left as an empty dict for CSV config files.
+        Configuration file loaded into a Python dictionary. Populated for both JSON and CSV config files
     output_dir : str | None
         Output folder for reduced data, default is current folder
     prim_wave : float
@@ -1080,7 +1080,12 @@ def parse_args():
 
     parser = argparse.ArgumentParser(description="USANS Data Reduction")
     parser.add_argument("path", help="Path to the configuration file")
-    parser.add_argument("-l", "--logbin", action="store_true", help="Enable log-binning of data during reduction")
+    parser.add_argument(
+        "-l",
+        "--logbin",
+        action="store_true",
+        help="Enable log-binning of data during reduction. Option only valid for CSV files",
+    )
     parser.add_argument("-o", "--output", default="", help="Output folder for reduced data (default: current folder)")
     args = parser.parse_args()
     return args

--- a/src/usansred/reduce.py
+++ b/src/usansred/reduce.py
@@ -1,5 +1,6 @@
 import copy
 import csv
+import json
 import logging
 import math
 import os
@@ -190,6 +191,10 @@ class Sample(BaseModel):
         return len(self.data_reduced.q)
 
     @property
+    def config(self):
+        return self.experiment.config
+
+    @property
     def num_of_banks(self) -> int:
         """Number of detector banks in the Experiment"""
         return self.experiment.num_of_banks
@@ -207,6 +212,11 @@ class Sample(BaseModel):
 
     def dump_data_to_csv(self, filepath: str, data: IQData | XYData, title: str | None = None):
         """Dump IQ or XY data to a CSV file."""
+        output_dir = os.path.dirname(filepath)
+        if output_dir and not os.path.exists(output_dir):
+            logging.info(f"Output directory {output_dir} does not exist; creating it.")
+            os.makedirs(output_dir)
+
         data_dict = data.as_dict()
         keys = list(data_dict.keys())
 
@@ -238,6 +248,15 @@ class Sample(BaseModel):
         if detector_data and self.data:
             filepath = os.path.join(self.experiment.output_dir, f"UN_{self.name}_det_1_unscaled.txt")
             self.dump_data_to_csv(filepath, self.data)
+            if self.config.get("save_all_harmonics", False):
+                for i in range(1, self.num_of_banks):
+                    bank = i + 1  # start with the second order
+                    filepath = os.path.join(
+                        self.experiment.output_dir,
+                        f"bank_{bank}",
+                        f"UN_{self.name}_det_unscaled_harmonics.txt",
+                    )
+                    self.dump_data_to_csv(filepath, self.detector_data[i])
 
         if scaled_data:
             filepath = os.path.join(self.experiment.output_dir, f"UN_{self.name}_det_1.txt")
@@ -868,8 +887,11 @@ class Experiment(BaseModel):
 
     Attributes
     ----------
-    config : str
+    config_file : str
         Path to the configuration file
+    config : dict
+        Configuration file loaded into a Python dictionary. Populated only for
+        JSON config files; left as an empty dict for CSV config files.
     output_dir : str | None
         Output folder for reduced data, default is current folder
     prim_wave : float
@@ -886,7 +908,8 @@ class Experiment(BaseModel):
         Flag for log-binning, default is False
     """
 
-    config: str = Field(..., description="Path to the configuration file")
+    config_file: str = Field(..., description="Path to the configuration file")
+    config: dict = Field(default_factory=dict, description="configuration file loaded into a Python dictionary")
     output_dir: str = Field("", description="Output folder for reduced data")
     prim_wave: float = Field(3.6, description="Primary wavelength in Angstroms")
     darwin_width: float = Field(DARWIN_WIDTH, description="Darwin width")
@@ -904,7 +927,7 @@ class Experiment(BaseModel):
         """Post-validation initializer"""
 
         # The working folder for this experiment, default is current folder
-        _setupfile = os.path.abspath(self.config)
+        _setupfile = os.path.abspath(self.config_file)
         self.folder = os.path.dirname(_setupfile)
 
         if bool(self.output_dir) is False:  # in case `output_dir` is an empty string
@@ -912,11 +935,19 @@ class Experiment(BaseModel):
 
         self.num_of_banks: int = 4
 
-        if not os.path.exists(self.config):
-            raise FileNotFoundError(f"The file path: {self.config} does not exist")
+        if not os.path.exists(self.config_file):
+            raise FileNotFoundError(f"The file path: {self.config_file} does not exist")
 
-        self.folder = os.path.dirname(self.config)
-        background, samples = read_config(self.config)
+        self.folder = os.path.dirname(self.config_file)
+        self.config = {"save_all_harmonics": False}
+
+        _, extension = os.path.splitext(self.config_file)
+        if extension.lower() == ".json":
+            with open(self.config_file, "r") as f:
+                self.config.update(json.load(f))
+        config = read_config(self.config_file)
+        background = config["background"]
+        samples = config["samples"]
         if background is None:
             logging.warning("No background sample defined in the configuration file.")
             self.background = None
@@ -975,7 +1006,7 @@ def parse_args():
 def main():
     """Main function to run USANS data reduction"""
     args = parse_args()
-    experiment = Experiment(config=args.path, logbin=args.logbin, output_dir=args.output)
+    experiment = Experiment(config_file=args.path, logbin=args.logbin, output_dir=args.output)
     experiment.reduce()
     generate_report(config_file_path=args.path, output_dir=experiment.output_dir)
 

--- a/src/usansred/reduce.py
+++ b/src/usansred/reduce.py
@@ -254,7 +254,7 @@ class Sample(BaseModel):
                     filepath = os.path.join(
                         self.experiment.output_dir,
                         f"bank_{bank}",
-                        f"UN_{self.name}_det_unscaled_harmonics.txt",
+                        f"UN_{self.name}_unscaled.txt",
                     )
                     self.dump_data_to_csv(filepath, self.detector_data[i])
 

--- a/src/usansred/reduce.py
+++ b/src/usansred/reduce.py
@@ -443,11 +443,26 @@ class Sample(BaseModel):
         """Rescale data with thickness.
         Fit the I(Q) data to gaussian and calculate peak area.
 
+        For higher order harmonics, the peak area is estimated from the relative integrated rocking-curve areas
+        (M. Agamalian et al., "Progress on The Time-of-Flight Ultra Small Angle Neutron Scattering Instrument at SNS",
+        J. Phys.: Conf. Ser. 1021 (2018) 012033)
+
         Parameters
         ----------
         guess_init : bool
             Whether to guess initial parameters for fitting with differential_evolution.
         """
+
+        # ratio of integrated rocking-curve areas for higher order harmonics relative to the first harmonic
+        # Si(220), Bragg-angle 69.9 degrees
+        peak_area_ratio = [
+            1.0,  # n = 1, lambda = 3.60 A
+            0.131,  # n = 2, lambda = 1.80 A
+            0.081,  # n = 3, lambda = 1.20 A
+            0.0166,  # n = 4, lambda = 0.90 A
+            0.0093,  # n = 5, lambda = 0.72 A
+            0.00106,  # n = 6, lambda = 0.60 A
+        ]
 
         def _gaussian(x: np.ndarray, k0: float, k1: float, k2: float) -> np.ndarray:
             """The Gaussian equation according to Igor definition of gaussian curvefit.
@@ -512,16 +527,17 @@ class Sample(BaseModel):
         for b in range(self.num_of_banks):
             bank = b + 1
 
-            # 2*(Pi^2)*HarNo/(PrimWavel*3600*180)
+            # (2π / λ_n) * radians_per_arcsecond -- angle-to-Q conversion factor
             h_scale = 2 * (math.pi**2.0) * bank / (self.experiment.prim_wave * 3600.0 * 180.0)
-            # VertScale=VertAngle*(DarWidth/HarNo)*Pi/(3600*180)*Sthick//10
-            v_scale = (
-                self.experiment.v_angle
-                * (self.experiment.darwin_width / bank)
-                * math.pi
-                / (3600.0 * 180.0)
-                * self.thickness
-            )
+
+            # harmonic-dependent horizontal angular width, converted from arcseconds to radians
+            horizontal_rocking_width = self.experiment.darwin_width / bank * math.pi / (3600.0 * 180.0)
+
+            # analyzer solid angle ΔΩ = vertical angular width * horizontal angular width
+            analyzer_solid_angle = self.experiment.v_angle * horizontal_rocking_width
+
+            # analyzer solid angle ΔΩ * sample thickness
+            v_scale = analyzer_solid_angle * self.thickness
 
             if guess_init:
                 initial_vals = _generate_initial_parameters(np.array(self.data.q), np.array(self.data.i))
@@ -542,6 +558,7 @@ class Sample(BaseModel):
                 * initial_vals[1]
                 * math.sqrt(2.0)
                 / math.sqrt(2 * math.pi)
+                / peak_area_ratio[b]
             )
             dar_test = initial_vals[1] * math.sqrt(2.0) * (math.pi) ** 0.5 * bank / self.experiment.darwin_width
 
@@ -564,8 +581,26 @@ class Sample(BaseModel):
         return
 
     def stitch_data(self):
-        """Stitch scans together and store in property `self.data`"""
+        """Stitch scan data from each detector bank into per-bank intensity curves.
 
+        For each detector bank (harmonic), combine all scans in ``self.scans`` onto a single
+        Intensity-versus-Q profile. The Q values are taken from the monitor data
+        and assumed to correspond to thew Q values from the detector data.
+        Detector intensities and errors are normalized by the corresponding monitor intensity
+        before being added to the stitched output.
+
+        If two or more scans contain the same Q value, their normalized intensities
+        are combined into one point using the existing variance-based weighting
+        formula, and the combined uncertainty is stored as the square root of the
+        summed variance.
+
+        After all scans for a bank are processed, the stitched points are sorted by Q
+
+        The method also generates log messages for the raw scan theta ranges
+        and converted Q ranges in ``1/angstrom`` for the first detector bank.
+        Results are stored on ``self.detector_data``; no value is returned.
+        """
+        # Build one stitched Q/I/E curve for each detector bank(harmonic).
         for bank in range(self.num_of_banks):
             momentum_transfer = []
             intensity = []
@@ -573,26 +608,44 @@ class Sample(BaseModel):
             # transmission = []  # omitted for now
 
             for scan in self.scans:
-                it = list(
-                    zip(
-                        scan.monitor_data.iq_data.q,
-                        scan.monitor_data.iq_data.i,
-                        scan.monitor_data.iq_data.e,
-                        scan.detector_data[bank].iq_data.i,
-                        scan.detector_data[bank].iq_data.e,
-                    )
+                # Pair the scan Q axis and monitor counts with this bank's detector counts.
+                scan_data = zip(
+                    scan.monitor_data.iq_data.q,
+                    scan.monitor_data.iq_data.i,
+                    scan.monitor_data.iq_data.e,
+                    scan.detector_data[bank].iq_data.i,
+                    scan.detector_data[bank].iq_data.e,
                 )
 
-                for mq, mi, me, di, de in it:
-                    if mq in momentum_transfer:
-                        idx = momentum_transfer.index(mq)
-                        var = error[idx] ** 2 + (de / mi) ** 2
-                        intensity[idx] = (intensity[idx] * (error[idx] ** 2) + (di / mi) * (de / mi) ** 2) / var
-                        error[idx] = var**0.5
+                for (
+                    scan_q,
+                    monitor_intensity,
+                    monitor_error,
+                    detector_intensity,
+                    detector_error,
+                ) in scan_data:
+                    # Normalize detector counts and uncertainty by monitor counts.
+                    normalized_intensity = detector_intensity / monitor_intensity
+                    # Error propagation for a/b: σ = (a/b)*sqrt((σ_a/a)² + (σ_b/b)²)
+                    # Equivalent form avoids dividing by detector_intensity when it is zero.
+                    normalized_error = (
+                        np.sqrt(detector_error**2 + (normalized_intensity * monitor_error) ** 2) / monitor_intensity
+                    )
+
+                    if scan_q in momentum_transfer:
+                        # Merge repeated Q values from multiple scans into one stitched point.
+                        matched_q_index = momentum_transfer.index(scan_q)
+                        combined_variance = error[matched_q_index] ** 2 + normalized_error**2
+                        intensity[matched_q_index] = (
+                            intensity[matched_q_index] * (error[matched_q_index] ** 2)
+                            + normalized_intensity * normalized_error**2
+                        ) / combined_variance
+                        error[matched_q_index] = combined_variance**0.5
                     else:
-                        momentum_transfer.append(mq)
-                        intensity.append(di / mi)
-                        error.append(de / mi)
+                        # Add Q values that have not appeared in earlier scans.
+                        momentum_transfer.append(scan_q)
+                        intensity.append(normalized_intensity)
+                        error.append(normalized_error)
 
             # Sort by momentum transfer (outside the scan loop, inside the bank loop)
             sorted_indices = np.argsort(momentum_transfer)
@@ -600,6 +653,7 @@ class Sample(BaseModel):
             intensity = np.array(intensity)[sorted_indices]
             error = np.array(error)[sorted_indices]
 
+            # Store the stitched curve for this detector bank.
             self.detector_data.append(
                 IQData(
                     q=momentum_transfer.tolist(),
@@ -613,6 +667,7 @@ class Sample(BaseModel):
         theta_range_msg = ""
         q_range_msg = ""
 
+        # Log raw theta ranges and converted Q ranges for each scan.
         for scan in self.scans:
             q_range = f"{min(scan.detector_data[0].iq_data.q)} - {max(scan.detector_data[0].iq_data.q)}"
             theta_range_msg += f"Theta range for scan {scan.number}: {q_range}\n"

--- a/src/usansred/reduce_USANS.py
+++ b/src/usansred/reduce_USANS.py
@@ -14,7 +14,6 @@ from mantid.simpleapi import (
     LoadEventNexus,
     Rebin,
     StepScan,
-    SumSpectra,
     mtd,
 )
 from matplotlib import use
@@ -216,7 +215,7 @@ def main():
                     )
                     mtd["USANS_scan_detector"].getAxis(1).getUnit().setLabel("Counts", "Counts")
                     x_data = mtd["USANS_scan_detector"].readX(0)  # rotation angle (arcsec) of the analyzer
-                    y_data = mtd["USANS_scan_detector"].readY(0)  # total counts at dectector for each analyzer angle
+                    y_data = mtd["USANS_scan_detector"].readY(0)  # total counts at detector for each analyzer angle
                     e_data = mtd["USANS_scan_detector"].readE(0)
 
                     if i == 0:

--- a/src/usansred/reduce_USANS.py
+++ b/src/usansred/reduce_USANS.py
@@ -401,7 +401,7 @@ def main():
     if not os.path.exists(autodir):
         os.makedirs(autodir)
 
-    exp = reduce.Experiment(config=autocsvfile)
+    exp = reduce.Experiment(config_file=autocsvfile)
     exp.reduce(output_dir=autodir)
 
     generate_report(config_file_path=autocsvfile, output_dir=exp.outputFolder)

--- a/src/usansred/reduce_USANS.py
+++ b/src/usansred/reduce_USANS.py
@@ -215,8 +215,8 @@ def main():
                         OutputWorkspace="USANS_scan_detector",
                     )
                     mtd["USANS_scan_detector"].getAxis(1).getUnit().setLabel("Counts", "Counts")
-                    x_data = mtd["USANS_scan_detector"].readX(0)
-                    y_data = mtd["USANS_scan_detector"].readY(0)
+                    x_data = mtd["USANS_scan_detector"].readX(0)  # rotation angle (arcsec) of the analyzer
+                    y_data = mtd["USANS_scan_detector"].readY(0)  # total counts at dectector for each analyzer angle
                     e_data = mtd["USANS_scan_detector"].readE(0)
 
                     if i == 0:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,10 +63,10 @@ def mock_experiment():
     exp.output_dir = ""
     exp.num_of_banks = 1
     exp.prim_wave = 3.6
-    exp.logbin = False
+    exp.log_binning = False
     exp.v_angle = 0.042
     exp.min_q = 1e-6
-    exp.step_per_dec = 33
+    exp.config = {"save_all_harmonics": False, "binning": {"log_binning": False, "steps_per_decade": 33}}
     exp.background = None
     exp.samples = []
     return exp
@@ -81,10 +81,10 @@ def mock_experiment_2banks():
     exp.output_dir = ""
     exp.num_of_banks = 2
     exp.prim_wave = 3.6
-    exp.logbin = False
+    exp.log_binning = False
     exp.v_angle = 0.042
     exp.min_q = 1e-6
-    exp.step_per_dec = 33
+    exp.config = {"save_all_harmonics": False, "binning": {"log_binning": False, "steps_per_decade": 33}}
     exp.background = None
     exp.samples = []
     return exp

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,6 @@ def mock_experiment():
     exp.output_dir = ""
     exp.num_of_banks = 1
     exp.prim_wave = 3.6
-    exp.darwin_width = 5.1
     exp.logbin = False
     exp.v_angle = 0.042
     exp.min_q = 1e-6
@@ -82,7 +81,6 @@ def mock_experiment_2banks():
     exp.output_dir = ""
     exp.num_of_banks = 2
     exp.prim_wave = 3.6
-    exp.darwin_width = 5.1
     exp.logbin = False
     exp.v_angle = 0.042
     exp.min_q = 1e-6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,8 +65,7 @@ def mock_experiment():
     exp.prim_wave = 3.6
     exp.log_binning = False
     exp.v_angle = 0.042
-    exp.min_q = 1e-6
-    exp.config = {"save_all_harmonics": False, "binning": {"log_binning": False, "steps_per_decade": 33}}
+    exp.config = {"save_all_harmonics": False, "binning": {"log_binning": False, "steps_per_decade": 33, "q_min": 1e-6}}
     exp.background = None
     exp.samples = []
     return exp
@@ -83,8 +82,7 @@ def mock_experiment_2banks():
     exp.prim_wave = 3.6
     exp.log_binning = False
     exp.v_angle = 0.042
-    exp.min_q = 1e-6
-    exp.config = {"save_all_harmonics": False, "binning": {"log_binning": False, "steps_per_decade": 33}}
+    exp.config = {"save_all_harmonics": False, "binning": {"log_binning": False, "steps_per_decade": 33, "q_min": 1e-6}}
     exp.background = None
     exp.samples = []
     return exp

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def data_server():
 def mock_experiment():
     """Create a minimal Experiment with model_post_init bypassed."""
     with patch.object(Experiment, "model_post_init", return_value=None):
-        exp = Experiment(config="dummy.json")
+        exp = Experiment(config_file="dummy.json")
     exp.folder = ""
     exp.output_dir = ""
     exp.num_of_banks = 1
@@ -77,7 +77,7 @@ def mock_experiment():
 def mock_experiment_2banks():
     """Create a minimal Experiment with 2 detector banks."""
     with patch.object(Experiment, "model_post_init", return_value=None):
-        exp = Experiment(config="dummy.json")
+        exp = Experiment(config_file="dummy.json")
     exp.folder = ""
     exp.output_dir = ""
     exp.num_of_banks = 2

--- a/tests/data/example-config.json
+++ b/tests/data/example-config.json
@@ -3,7 +3,8 @@
     "name": "example_background",
     "start_scan_num": "45335",
     "num_of_scans": 6,
-    "thickness": 0.1
+    "thickness": 0.1,
+    "exclude": [45336]
   },
   "binning": {
     "log_binning": false,

--- a/tests/data/example-config.json
+++ b/tests/data/example-config.json
@@ -5,6 +5,10 @@
     "num_of_scans": 6,
     "thickness": 0.1
   },
+  "binning": {
+    "log_binning": false,
+    "steps_per_decade": 33
+  },
   "samples": [
     {
       "name": "sample1",

--- a/tests/integration/test_reduce.py
+++ b/tests/integration/test_reduce.py
@@ -79,7 +79,7 @@ def test_sample_match_or_interpolate(data_server, tmp_path):
     # Create new Experiment instance
     csvpath = data_server.path_to("setup.csv")
     tmpoutput = str(tmp_path)
-    exp = Experiment(config=csvpath, logbin=False, output_dir=tmpoutput)
+    exp = Experiment(config_file=csvpath, logbin=False, output_dir=tmpoutput)
 
     # Genearte testing data
     qq = np.array([dd * 1e-5 for dd in range(1, 100)])

--- a/tests/integration/test_reduce.py
+++ b/tests/integration/test_reduce.py
@@ -39,7 +39,9 @@ def compare_lines(file1, file2, threshold=0.01):
             except ZeroDivisionError:
                 pass
             if relative_diff > threshold:
-                raise ValueError(f"Line {i}, Number {num1:.6f} differs significantly from {num2:.6f}")
+                # DEBUG:
+                pass
+                # raise ValueError(f"Line {i}, Number {num1:.6f} differs significantly from {num2:.6f}")
 
 
 @mock_patch("usansred.reduce.parse_args")
@@ -61,17 +63,23 @@ def test_main(mock_parse_args, data_server, tmp_path):
     # Setup mock objects
     mock_args = MagicMock()
     mock_args.logbin = False
-    mock_args.path = data_server.path_to("setup.csv")
+    mock_args.path = data_server.path_to("setup.json")
     mock_args.output = str(tmp_path)
     mock_parse_args.return_value = mock_args
     reduce()
     # compare the content of output files with files containing expected results
     goldendir = os.path.join(os.path.dirname(mock_args.path), "reduced")  # where the expected content resides
-    for name in ["EmptyPCell", "S115_dry", "S115_pc3"]:
-        for suffix in ["", "_lbs", "_lb", "_unscaled"]:
+    for name in ["S115_pc3", "S115_dry", "EmptyPCell"]:
+        file_suffixes = {
+            "unscaled data": "_unscaled",
+            "scaled data": "",
+            "log binned data": "_lb",
+            "log binned and background subtracted": "_lbs",
+        }
+        for suffix in file_suffixes.values():
             filename = f"UN_{name}_det_1{suffix}.txt"
             output, expected = os.path.join(tmp_path, filename), os.path.join(goldendir, filename)
-            if os.path.exists(expected) and os.path.exists(output):  # file "UN_EmptyPCell_det_1_lbs.txt" does not exist
+            if os.path.exists(expected) and os.path.exists(output):  # "UN_EmptyPCell_det_1_lbs.txt" doesn't exist
                 compare_lines(output, expected)
 
 
@@ -108,6 +116,10 @@ def test_main_save_all_harmonics(mock_parse_args, data_server, tmp_path):
             assert harmonic_file.is_file()
             assert harmonic_file.stat().st_size > 0
             assert len(harmonic_file.read_text(encoding="utf-8").splitlines()) == 65
+
+            scaled_file = bank_dir / f"UN_{name}.txt"
+            assert scaled_file.is_file()
+            assert scaled_file.stat().st_size > 0
 
 
 @pytest.mark.datarepo

--- a/tests/integration/test_reduce.py
+++ b/tests/integration/test_reduce.py
@@ -39,9 +39,7 @@ def compare_lines(file1, file2, threshold=0.01):
             except ZeroDivisionError:
                 pass
             if relative_diff > threshold:
-                # DEBUG:
-                pass
-                # raise ValueError(f"Line {i}, Number {num1:.6f} differs significantly from {num2:.6f}")
+                raise ValueError(f"Line {i}, Number {num1:.6f} differs significantly from {num2:.6f}")
 
 
 @mock_patch("usansred.reduce.parse_args")

--- a/tests/integration/test_reduce.py
+++ b/tests/integration/test_reduce.py
@@ -1,5 +1,7 @@
+import json
 import os
 import random
+from pathlib import Path
 from unittest.mock import MagicMock
 from unittest.mock import patch as mock_patch
 
@@ -71,6 +73,41 @@ def test_main(mock_parse_args, data_server, tmp_path):
             output, expected = os.path.join(tmp_path, filename), os.path.join(goldendir, filename)
             if os.path.exists(expected) and os.path.exists(output):  # file "UN_EmptyPCell_det_1_lbs.txt" does not exist
                 compare_lines(output, expected)
+
+
+@pytest.mark.datarepo
+@mock_patch("usansred.reduce.parse_args")
+def test_main_save_all_harmonics(mock_parse_args, data_server, tmp_path):
+    source_config = Path(data_server.path_to("setup.json"))
+    source_data_dir = source_config.parent
+    reduction_data_dir = tmp_path / "data"
+    reduction_data_dir.mkdir()
+
+    for source_file in source_data_dir.glob("USANS_*.txt"):
+        (reduction_data_dir / source_file.name).symlink_to(source_file)
+
+    config = json.loads(source_config.read_text(encoding="utf-8"))
+    config["save_all_harmonics"] = True
+    config_file = reduction_data_dir / "setup.json"
+    config_file.write_text(json.dumps(config), encoding="utf-8")
+
+    output_dir = tmp_path / "reduced"
+    mock_args = MagicMock()
+    mock_args.logbin = False
+    mock_args.path = str(config_file)
+    mock_args.output = str(output_dir)
+    mock_parse_args.return_value = mock_args
+
+    reduce()
+
+    for bank in range(2, 5):
+        bank_dir = output_dir / f"bank_{bank}"
+        assert bank_dir.is_dir()
+        for name in ["EmptyPCell", "S115_dry", "S115_pc3"]:
+            harmonic_file = bank_dir / f"UN_{name}_unscaled.txt"
+            assert harmonic_file.is_file()
+            assert harmonic_file.stat().st_size > 0
+            assert len(harmonic_file.read_text(encoding="utf-8").splitlines()) == 65
 
 
 @pytest.mark.datarepo

--- a/tests/integration/test_reduce.py
+++ b/tests/integration/test_reduce.py
@@ -128,7 +128,7 @@ def test_sample_match_or_interpolate(data_server, tmp_path):
     # Create new Experiment instance
     csvpath = data_server.path_to("setup.csv")
     tmpoutput = str(tmp_path)
-    exp = Experiment(config_file=csvpath, logbin=False, output_dir=tmpoutput)
+    exp = Experiment(config_file=csvpath, log_binning=False, output_dir=tmpoutput)
 
     # Genearte testing data
     qq = np.array([dd * 1e-5 for dd in range(1, 100)])

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -25,7 +25,6 @@ def mock_experiment():
     exp.output_dir = ""
     exp.num_of_banks = 1
     exp.prim_wave = 3.6
-    exp.darwin_width = 5.1
     exp.logbin = False
     exp.v_angle = 0.042
     exp.min_q = 1e-6
@@ -44,7 +43,6 @@ def mock_experiment_2banks():
     exp.output_dir = ""
     exp.num_of_banks = 2
     exp.prim_wave = 3.6
-    exp.darwin_width = 5.1
     exp.logbin = False
     exp.v_angle = 0.042
     exp.min_q = 1e-6

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -20,7 +20,7 @@ def test_data_server(data_server):
 def mock_experiment():
     """Create a minimal Experiment with model_post_init bypassed."""
     with patch.object(Experiment, "model_post_init", return_value=None):
-        exp = Experiment(config="dummy.json")
+        exp = Experiment(config_file="dummy.json")
     exp.folder = ""
     exp.output_dir = ""
     exp.num_of_banks = 1
@@ -39,7 +39,7 @@ def mock_experiment():
 def mock_experiment_2banks():
     """Create a minimal Experiment with 2 detector banks."""
     with patch.object(Experiment, "model_post_init", return_value=None):
-        exp = Experiment(config="dummy.json")
+        exp = Experiment(config_file="dummy.json")
     exp.folder = ""
     exp.output_dir = ""
     exp.num_of_banks = 2

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,12 +1,10 @@
-import math
 import os
 from unittest.mock import patch
 
-import numpy as np
 import pytest
 
 from usansred.model import IQData, MonitorData, XYData
-from usansred.reduce import CombinedSample, Experiment, Sample, Scan
+from usansred.reduce import Experiment, Sample, Scan
 
 
 @pytest.mark.datarepo

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -25,10 +25,10 @@ def mock_experiment():
     exp.output_dir = ""
     exp.num_of_banks = 1
     exp.prim_wave = 3.6
-    exp.logbin = False
+    exp.log_binning = False
     exp.v_angle = 0.042
     exp.min_q = 1e-6
-    exp.step_per_dec = 33
+    exp.config = {"save_all_harmonics": False, "binning": {"log_binning": False, "steps_per_decade": 33}}
     exp.background = None
     exp.samples = []
     return exp
@@ -43,10 +43,10 @@ def mock_experiment_2banks():
     exp.output_dir = ""
     exp.num_of_banks = 2
     exp.prim_wave = 3.6
-    exp.logbin = False
+    exp.log_binning = False
     exp.v_angle = 0.042
     exp.min_q = 1e-6
-    exp.step_per_dec = 33
+    exp.config = {"save_all_harmonics": False, "binning": {"log_binning": False, "steps_per_decade": 33}}
     exp.background = None
     exp.samples = []
     return exp

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -27,8 +27,7 @@ def mock_experiment():
     exp.prim_wave = 3.6
     exp.log_binning = False
     exp.v_angle = 0.042
-    exp.min_q = 1e-6
-    exp.config = {"save_all_harmonics": False, "binning": {"log_binning": False, "steps_per_decade": 33}}
+    exp.config = {"save_all_harmonics": False, "binning": {"log_binning": False, "steps_per_decade": 33, "q_min": 1e-6}}
     exp.background = None
     exp.samples = []
     return exp
@@ -45,8 +44,7 @@ def mock_experiment_2banks():
     exp.prim_wave = 3.6
     exp.log_binning = False
     exp.v_angle = 0.042
-    exp.min_q = 1e-6
-    exp.config = {"save_all_harmonics": False, "binning": {"log_binning": False, "steps_per_decade": 33}}
+    exp.config = {"save_all_harmonics": False, "binning": {"log_binning": False, "steps_per_decade": 33, "q_min": 1e-6}}
     exp.background = None
     exp.samples = []
     return exp

--- a/tests/unit/io/test_read.py
+++ b/tests/unit/io/test_read.py
@@ -4,8 +4,11 @@ Note: We need to patch the Experiment and Sample model_post_init methods
 to avoid issues with missing attributes during testing.
 """
 
+import json
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from usansred.io.read import read_config
 from usansred.reduce import Experiment, Sample
@@ -13,14 +16,22 @@ from usansred.reduce import Experiment, Sample
 DATA_DIR = Path(__file__).parent.parent.parent / "data"
 
 
+def _write_json_config(tmp_path: Path, config: dict) -> Path:
+    config_file = tmp_path / "setup.json"
+    config_file.write_text(json.dumps(config), encoding="utf-8")
+    return config_file
+
+
 def test_read_config_csv():
     """Test reading configuration from a CSV file."""
 
     csv_file = DATA_DIR / "example-config.csv"
-    background, samples = read_config(csv_file)
+    config = read_config(csv_file)
+    background = config["background"]
+    samples = config["samples"]
 
     with patch.object(Experiment, "model_post_init", return_value=None):
-        experiment = Experiment(config="dummy.csv")
+        experiment = Experiment(config_file="dummy.csv")
 
     with patch.object(Sample, "model_post_init", return_value=None):
         background = Sample(**background, experiment=experiment) if background else None
@@ -37,10 +48,12 @@ def test_read_config_json():
     """Test reading configuration from a JSON file."""
 
     json_file = DATA_DIR / "example-config.json"
-    background, samples = read_config(json_file)
+    config = read_config(json_file)
+    background = config["background"]
+    samples = config["samples"]
 
     with patch.object(Experiment, "model_post_init", return_value=None):
-        experiment = Experiment(config="dummy.json")
+        experiment = Experiment(config_file="dummy.json")
 
     with patch.object(Sample, "model_post_init", return_value=None):
         background = Sample(**background, experiment=experiment) if background else None
@@ -54,14 +67,100 @@ def test_read_config_json():
     assert samples[1].exclude == [45307, 45308]
 
 
+def test_read_config_json_applies_schema_defaults(tmp_path):
+    """Test that schema defaults are inserted before JSON configuration parsing."""
+
+    json_file = _write_json_config(
+        tmp_path,
+        {
+            "samples": [
+                {
+                    "name": "sample1",
+                    "start_scan_num": "45306",
+                    "num_of_scans": 6,
+                    "thickness": 0.1,
+                }
+            ]
+        },
+    )
+
+    config = read_config(json_file)
+
+    assert config["save_all_harmonics"] is False
+    assert config["samples"][0]["exclude"] == []
+
+
+def test_read_config_json_missing_samples_raises(tmp_path):
+    """Test that missing required properties without defaults raise an exception."""
+
+    json_file = _write_json_config(
+        tmp_path,
+        {
+            "background": {
+                "name": "example_background",
+                "start_scan_num": "45335",
+                "num_of_scans": 6,
+                "thickness": 0.1,
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match="Required property 'samples' is missing"):
+        read_config(json_file)
+
+
+def test_read_config_json_missing_sample_required_property_raises(tmp_path):
+    """Test that missing required sample properties without defaults raise an exception."""
+
+    json_file = _write_json_config(
+        tmp_path,
+        {
+            "samples": [
+                {
+                    "start_scan_num": "45306",
+                    "num_of_scans": 6,
+                    "thickness": 0.1,
+                }
+            ]
+        },
+    )
+
+    with pytest.raises(ValueError, match="Required property 'name' is missing"):
+        read_config(json_file)
+
+
+def test_read_config_json_unexpected_property_raises(tmp_path):
+    """Test that schema validation rejects unexpected JSON properties."""
+
+    json_file = _write_json_config(
+        tmp_path,
+        {
+            "samples": [
+                {
+                    "name": "sample1",
+                    "start_scan_num": "45306",
+                    "num_of_scans": 6,
+                    "thickness": 0.1,
+                    "unexpected": True,
+                }
+            ]
+        },
+    )
+
+    with pytest.raises(ValueError, match="Additional properties are not allowed: 'unexpected'"):
+        read_config(json_file)
+
+
 def test_read_config_json_no_background():
     """Test reading configuration from a JSON file with no background sample."""
 
     json_file = DATA_DIR / "example-config-no-bg.json"
-    background, samples = read_config(json_file)
+    config = read_config(json_file)
+    background = config["background"]
+    samples = config["samples"]
 
     with patch.object(Experiment, "model_post_init", return_value=None):
-        experiment = Experiment(config="dummy.json")
+        experiment = Experiment(config_file="dummy.json")
 
     with patch.object(Sample, "model_post_init", return_value=None):
         background = Sample(**background, experiment=experiment) if background else None

--- a/tests/unit/io/test_read.py
+++ b/tests/unit/io/test_read.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 import pytest
 from jsonschema import Draft202012Validator
 
-from usansred.io.read import read_config
+from usansred.io.read import cast_to_bool, read_config
 from usansred.reduce import Experiment, Sample
 
 DATA_DIR = Path(__file__).parent.parent.parent / "data"
@@ -22,6 +22,25 @@ def _write_json_config(tmp_path: Path, config: dict) -> Path:
     config_file = tmp_path / "setup.json"
     config_file.write_text(json.dumps(config), encoding="utf-8")
     return config_file
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (True, True),
+        (False, False),
+        (1, True),
+        (0, False),
+        ("1", True),
+        ("0", False),
+        ("True", True),
+        ("False", False),
+        ("", False),
+    ],
+)
+def test_cast_to_bool(value, expected):
+    """Test casting common setup-file boolean values."""
+    assert cast_to_bool(value) is expected
 
 
 def test_read_config_csv():

--- a/tests/unit/io/test_read.py
+++ b/tests/unit/io/test_read.py
@@ -61,6 +61,7 @@ def test_read_config_json():
 
     assert background is not None
     assert background.name == "example_background"
+    assert background.exclude == [45336]
     assert len(samples) == 2
     assert samples[0].name == "sample1"
     assert samples[1].name == "sample2"

--- a/tests/unit/io/test_read.py
+++ b/tests/unit/io/test_read.py
@@ -87,6 +87,8 @@ def test_read_config_json_applies_schema_defaults(tmp_path):
     config = read_config(json_file)
 
     assert config["save_all_harmonics"] is False
+    assert config["binning"]["log_binning"] is False
+    assert config["binning"]["steps_per_decade"] == 33
     assert config["samples"][0]["exclude"] == []
 
 

--- a/tests/unit/io/test_read.py
+++ b/tests/unit/io/test_read.py
@@ -5,10 +5,12 @@ to avoid issues with missing attributes during testing.
 """
 
 import json
+from importlib import resources
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from jsonschema import Draft202012Validator
 
 from usansred.io.read import read_config
 from usansred.reduce import Experiment, Sample
@@ -42,6 +44,20 @@ def test_read_config_csv():
     assert samples[0].name == "sample1"
     assert samples[1].name == "sample2"
     assert samples[1].exclude == [12345, 67890]
+
+
+def test_read_config_csv_applies_schema_defaults(tmp_path):
+    """Schema defaults (save_all_harmonics, binning, exclude) are injected for CSV configs."""
+
+    csv_file = tmp_path / "setup.csv"
+    csv_file.write_text("s,sample1,45306,6,0.1\n", encoding="utf-8")
+
+    config = read_config(csv_file)
+
+    assert config["save_all_harmonics"] is False
+    assert config["binning"]["log_binning"] is False
+    assert config["binning"]["steps_per_decade"] == 33
+    assert config["samples"][0]["exclude"] == []
 
 
 def test_read_config_json():
@@ -91,6 +107,27 @@ def test_read_config_json_applies_schema_defaults(tmp_path):
     assert config["binning"]["log_binning"] is False
     assert config["binning"]["steps_per_decade"] == 33
     assert config["samples"][0]["exclude"] == []
+
+
+def test_usansred_schema_treats_save_all_harmonics_as_optional():
+    """The bundled schema validates configs that omit save_all_harmonics."""
+
+    schema_path = resources.files("usansred.io").joinpath("usansred.json")
+    with schema_path.open("r", encoding="utf-8") as schema_file:
+        schema = json.load(schema_file)
+
+    config = {
+        "samples": [
+            {
+                "name": "sample1",
+                "start_scan_num": "45306",
+                "num_of_scans": 6,
+                "thickness": 0.1,
+            }
+        ]
+    }
+
+    Draft202012Validator(schema).validate(config)
 
 
 def test_read_config_json_missing_samples_raises(tmp_path):

--- a/tests/unit/test_combined_sample.py
+++ b/tests/unit/test_combined_sample.py
@@ -2,14 +2,13 @@
 
 import logging
 import math
-from unittest.mock import patch
 
 import numpy as np
 import pytest
 
 from tests.test_fixtures import _make_sample, _make_scan, _make_scan_multi_bank
-from usansred.model import IQData, MonitorData, XYData
-from usansred.reduce import CombinedSample, Experiment, Sample, Scan
+from usansred.model import XYData
+from usansred.reduce import CombinedSample
 
 # ===========================================================================
 # Tests for _combine_xy_data_pair (static helper)

--- a/tests/unit/test_experiment.py
+++ b/tests/unit/test_experiment.py
@@ -1,0 +1,60 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+from usansred.reduce import Experiment, Sample
+
+
+class TestLogBinning:
+    MINIMAL_CONFIG = {
+        "samples": [{"name": "s", "start_scan_num": 1, "num_of_scans": 1, "thickness": 0.1}],
+    }
+
+    @pytest.mark.parametrize(
+        ("config_extra", "expected_log_binning", "expected_steps_per_decade"),
+        [
+            ({"binning": {"log_binning": True, "steps_per_decade": 44}}, True, 44),
+            ({"binning": {"log_binning": 1}}, True, 33),
+            ({"binning": {"log_binning": False}}, False, 33),
+            ({"binning": {"log_binning": 0}}, False, 33),
+            ({"binning": {"log_binning": ""}}, False, 33),
+            ({}, False, 33),  # absent → defaults to False
+        ],
+    )
+    def test_log_binning_from_json_config(
+        self, tmp_path, config_extra, expected_log_binning, expected_steps_per_decade
+    ):
+        config_file = tmp_path / "setup.json"
+        config_file.write_text(json.dumps({**self.MINIMAL_CONFIG, **config_extra}), encoding="utf-8")
+
+        with patch.object(Sample, "model_post_init", return_value=None):
+            experiment = Experiment(config_file=str(config_file))
+
+        assert experiment.log_binning is expected_log_binning
+        assert experiment.config["binning"]["steps_per_decade"] == expected_steps_per_decade
+
+    def test_cli_logbin_overrides_json_config(self, tmp_path):
+        """CLI --logbin=True takes precedence over binning.log_binning: false in the JSON."""
+        config_file = tmp_path / "setup.json"
+        config_file.write_text(
+            json.dumps({**self.MINIMAL_CONFIG, "binning": {"log_binning": False, "steps_per_decade": 44}}),
+            encoding="utf-8",
+        )
+
+        with patch.object(Sample, "model_post_init", return_value=None):
+            experiment = Experiment(config_file=str(config_file), log_binning=True)
+
+        assert experiment.log_binning is True
+        assert experiment.config["binning"]["steps_per_decade"] == 44
+
+    def test_json_log_binning_governs_when_cli_not_set(self, tmp_path):
+        """JSON binning.log_binning: true takes effect when CLI --logbin is not passed."""
+        config_file = tmp_path / "setup.json"
+        config_file.write_text(json.dumps({**self.MINIMAL_CONFIG, "binning": {"log_binning": True}}), encoding="utf-8")
+
+        with patch.object(Sample, "model_post_init", return_value=None):
+            experiment = Experiment(config_file=str(config_file), log_binning=False)
+
+        assert experiment.log_binning is True
+        assert experiment.config["binning"]["steps_per_decade"] == 33

--- a/tests/unit/test_experiment.py
+++ b/tests/unit/test_experiment.py
@@ -43,7 +43,8 @@ class TestLogBinning:
         )
 
         with patch.object(Sample, "model_post_init", return_value=None):
-            experiment = Experiment(config_file=str(config_file), log_binning=True)
+            experiment = Experiment(config_file=str(config_file))
+        experiment.amend_log_binning(True)
 
         assert experiment.log_binning is True
         assert experiment.config["binning"]["steps_per_decade"] == 44

--- a/tests/unit/test_sample.py
+++ b/tests/unit/test_sample.py
@@ -111,6 +111,41 @@ class TestSampleNormalizeByMonitor:
         assert normalized_scan_numbers == [1, 2]
 
 
+class TestSampleStitchScans:
+    """Tests for Sample.stitch_scans."""
+
+    @staticmethod
+    def _make_scan_with_detector_iq(experiment: Experiment, q: list[float], i: list[float], e: list[float]) -> Scan:
+        scan = Scan(number=123, experiment=experiment, load_data=False)
+        scan.detector_data = [MonitorData(iq_data=IQData(q=q, i=i, e=e))]
+        return scan
+
+    def test_combines_duplicate_q_points_with_inverse_variance_weights(self, mock_experiment):
+        """Duplicate Q points should weight lower-variance intensities more strongly."""
+        scan_1 = self._make_scan_with_detector_iq(
+            mock_experiment,
+            q=[1.0, 2.0],
+            i=[100.0, 20.0],
+            e=[1.0, 2.0],
+        )
+        scan_2 = self._make_scan_with_detector_iq(
+            mock_experiment,
+            q=[1.0, 3.0],
+            i=[200.0, 30.0],
+            e=[3.0, 3.0],
+        )
+        sample = _make_sample(mock_experiment, "test", [scan_1, scan_2])
+
+        sample.stitch_scans()
+
+        expected_weight_sum = 1.0 / 1.0**2 + 1.0 / 3.0**2
+        expected_intensity = (100.0 / 1.0**2 + 200.0 / 3.0**2) / expected_weight_sum
+        expected_error = np.sqrt(1.0 / expected_weight_sum)
+        np.testing.assert_allclose(sample.detector_data[0].q, [1.0, 2.0, 3.0])
+        np.testing.assert_allclose(sample.detector_data[0].i, [expected_intensity, 20.0, 30.0])
+        np.testing.assert_allclose(sample.detector_data[0].e, [expected_error, 2.0, 3.0])
+
+
 class TestCombineDuplicateQPoints:
     """Tests for Sample._combine_duplicate_q_points."""
 

--- a/tests/unit/test_sample.py
+++ b/tests/unit/test_sample.py
@@ -10,8 +10,8 @@ from unittest.mock import patch
 import numpy as np
 
 from tests.test_fixtures import _make_sample
-from usansred.model import IQData, XYData
-from usansred.reduce import Experiment, Sample, Scan
+from usansred.model import IQData, MonitorData, XYData
+from usansred.reduce import ARCSEC_TO_RADIANS, Experiment, Sample, Scan, horizontal_rocking_width
 
 
 class TestSampleProperties:
@@ -90,6 +90,145 @@ class TestSampleProperties:
         """num_of_banks should delegate to experiment."""
         sample = _make_sample(mock_experiment, "test", [])
         assert sample.num_of_banks == mock_experiment.num_of_banks
+
+
+class TestSampleNormalizeByMonitor:
+    """Tests for Sample.normalize_by_monitor."""
+
+    def test_normalizes_each_scan(self, mock_experiment):
+        """Sample normalization should delegate to every scan."""
+        scan_1 = Scan(number=1, experiment=mock_experiment, load_data=False)
+        scan_2 = Scan(number=2, experiment=mock_experiment, load_data=False)
+        sample = _make_sample(mock_experiment, "test", [scan_1, scan_2])
+        normalized_scan_numbers = []
+
+        def record_normalized_scan(scan):
+            normalized_scan_numbers.append(scan.number)
+
+        with patch.object(Scan, "normalize_by_monitor", autospec=True, side_effect=record_normalized_scan):
+            sample.normalize_by_monitor()
+
+        assert normalized_scan_numbers == [1, 2]
+
+
+class TestCombineDuplicateQPoints:
+    """Tests for Sample._combine_duplicate_q_points."""
+
+    def test_sorts_q_and_averages_duplicate_points(self):
+        """Duplicate Q points should be averaged and returned in ascending Q order."""
+        q, i, e = Sample._combine_duplicate_q_points(
+            q_scaled=[2.0, 1.0, 0.0, 1.0, 2.0],
+            i_scaled=[20.0, 10.0, 5.0, 14.0, 30.0],
+            e_scaled=[2.0, 1.0, 0.5, 3.0, 4.0],
+        )
+
+        np.testing.assert_allclose(q, [0.0, 1.0, 2.0])
+        np.testing.assert_allclose(i, [5.0, 12.0, 25.0])
+        np.testing.assert_allclose(e, [0.5, np.sqrt(10.0) / 2.0, np.sqrt(20.0) / 2.0])
+
+
+class TestSampleRescaleData:
+    """Tests for Sample.rescale_data."""
+
+    @staticmethod
+    def _make_rescale_sample(experiment: Experiment, detector_data: list[IQData], thickness: float = 0.2) -> Sample:
+        scan = Scan(number=123, experiment=experiment, load_data=False)
+        sample = _make_sample(experiment, "test", [scan])
+        sample.thickness = thickness
+        sample.detector_data = detector_data
+        return sample
+
+    @staticmethod
+    def _expected_rescaled_data(
+        experiment: Experiment, harmonic: int, thickness: float, detector_data: IQData
+    ) -> tuple[list[float], list[float], list[float]]:
+        theta_to_q = ARCSEC_TO_RADIANS * (2 * np.pi / (experiment.prim_wave / harmonic))
+        analyzer_solid_angle = experiment.v_angle * (horizontal_rocking_width(harmonic) * ARCSEC_TO_RADIANS)
+        scaling_factor = 1.0 / (analyzer_solid_angle * thickness)
+
+        q_scaled = [abs(theta) * theta_to_q for theta in detector_data.q]
+        i_scaled = [i * scaling_factor for i in detector_data.i]
+        e_scaled = [e * scaling_factor for e in detector_data.e]
+        return Sample._combine_duplicate_q_points(q_scaled, i_scaled, e_scaled)
+
+    def test_scales_single_bank_by_q_conversion_solid_angle_and_thickness(self, mock_experiment):
+        detector_data = IQData(q=[0.0, 1.0, 3.0], i=[2.0, 4.0, 6.0], e=[0.2, 0.4, 0.6])
+        sample = self._make_rescale_sample(mock_experiment, [detector_data], thickness=0.4)
+
+        sample.rescale_data()
+
+        expected_q, expected_i, expected_e = self._expected_rescaled_data(
+            mock_experiment, harmonic=1, thickness=sample.thickness, detector_data=detector_data
+        )
+        assert len(sample.data_scaled) == 1
+        np.testing.assert_allclose(sample.data_scaled[0].q, expected_q)
+        np.testing.assert_allclose(sample.data_scaled[0].i, expected_i)
+        np.testing.assert_allclose(sample.data_scaled[0].e, expected_e)
+
+    def test_combines_positive_and_negative_angles_into_sorted_q(self, mock_experiment):
+        detector_data = IQData(
+            q=[-2.0, -1.0, 0.0, 1.0, 2.0],
+            i=[20.0, 10.0, 5.0, 14.0, 30.0],
+            e=[2.0, 1.0, 0.5, 3.0, 4.0],
+        )
+        sample = self._make_rescale_sample(mock_experiment, [detector_data], thickness=0.2)
+
+        sample.rescale_data()
+
+        expected_q, expected_i, expected_e = self._expected_rescaled_data(
+            mock_experiment, harmonic=1, thickness=sample.thickness, detector_data=detector_data
+        )
+        np.testing.assert_allclose(sample.data_scaled[0].q, expected_q)
+        np.testing.assert_allclose(sample.data_scaled[0].i, expected_i)
+        np.testing.assert_allclose(sample.data_scaled[0].e, expected_e)
+        assert sample.data_scaled[0].q == sorted(sample.data_scaled[0].q)
+
+    def test_scales_each_harmonic_from_its_detector_bank(self, mock_experiment_2banks):
+        bank_1_data = IQData(q=[0.0, 1.0, 2.0], i=[10.0, 20.0, 30.0], e=[1.0, 2.0, 3.0])
+        bank_2_data = IQData(q=[0.0, 2.0, 4.0], i=[100.0, 200.0, 300.0], e=[10.0, 20.0, 30.0])
+        sample = self._make_rescale_sample(mock_experiment_2banks, [bank_1_data, bank_2_data], thickness=0.3)
+
+        sample.rescale_data()
+
+        expected_bank_1 = self._expected_rescaled_data(
+            mock_experiment_2banks, harmonic=1, thickness=sample.thickness, detector_data=bank_1_data
+        )
+        expected_bank_2 = self._expected_rescaled_data(
+            mock_experiment_2banks, harmonic=2, thickness=sample.thickness, detector_data=bank_2_data
+        )
+        assert len(sample.data_scaled) == 2
+        np.testing.assert_allclose(sample.data_scaled[0].q, expected_bank_1[0])
+        np.testing.assert_allclose(sample.data_scaled[0].i, expected_bank_1[1])
+        np.testing.assert_allclose(sample.data_scaled[0].e, expected_bank_1[2])
+        np.testing.assert_allclose(sample.data_scaled[1].q, expected_bank_2[0])
+        np.testing.assert_allclose(sample.data_scaled[1].i, expected_bank_2[1])
+        np.testing.assert_allclose(sample.data_scaled[1].e, expected_bank_2[2])
+
+
+class TestRockingCurveCentering:
+    """Tests for Sample.rocking_curve_centering."""
+
+    def test_centers_all_harmonics_using_symmetric_first_harmonic_range(self, mock_experiment_2banks):
+        """Only the first harmonic's mostly symmetric range should define the center."""
+        sample = _make_sample(mock_experiment_2banks, "test", [])
+        q_first = np.linspace(-2.0, 4.0, 31)
+        q_second = np.linspace(-4.0, 8.0, 31)
+        expected_center = 0.35
+        width = 0.6
+        baseline = 0.2
+        amplitude = 12.0
+        intensity = baseline + amplitude * np.exp(-0.5 * ((q_first - expected_center) / width) ** 2)
+        intensity[q_first > 2.0] = 50.0
+        sample.detector_data = [
+            IQData(q=q_first.tolist(), i=intensity.tolist(), e=[0.01] * len(q_first)),
+            IQData(q=q_second.tolist(), i=[1.0] * len(q_second), e=[0.01] * len(q_second)),
+        ]
+
+        center = sample.rocking_curve_centering()
+
+        np.testing.assert_allclose(center, expected_center)
+        np.testing.assert_allclose(sample.detector_data[0].q, q_first - expected_center)
+        np.testing.assert_allclose(sample.detector_data[1].q, q_second - expected_center)
 
 
 class TestSampleEquality:

--- a/tests/unit/test_scan.py
+++ b/tests/unit/test_scan.py
@@ -108,6 +108,37 @@ class TestScanConvertXYToIQ:
         np.testing.assert_allclose(iq.e, [math.sqrt(6.0)])
 
 
+class TestScanNormalizeByMonitor:
+    """Tests for Scan.normalize_by_monitor."""
+
+    def test_normalizes_detector_iq_data_by_monitor_counts(self, mock_experiment_2banks):
+        """Detector intensities and errors should be normalized for each bank."""
+        scan = Scan(number=0, experiment=mock_experiment_2banks, load_data=False)
+        scan.monitor_data = MonitorData(iq_data=IQData(q=[1.0, 2.0], i=[100.0, 200.0], e=[10.0, 20.0]))
+        scan.detector_data = [
+            MonitorData(iq_data=IQData(q=[1.0, 2.0], i=[50.0, 100.0], e=[5.0, 10.0], t=[7.0, 8.0])),
+            MonitorData(iq_data=IQData(q=[1.0, 2.0], i=[25.0, 50.0], e=[2.5, 5.0])),
+        ]
+
+        scan.normalize_by_monitor()
+
+        expected_first_error = [
+            math.sqrt(5.0**2 + (0.5 * 10.0) ** 2) / 100.0,
+            math.sqrt(10.0**2 + (0.5 * 20.0) ** 2) / 200.0,
+        ]
+        expected_second_error = [
+            math.sqrt(2.5**2 + (0.25 * 10.0) ** 2) / 100.0,
+            math.sqrt(5.0**2 + (0.25 * 20.0) ** 2) / 200.0,
+        ]
+
+        np.testing.assert_allclose(scan.detector_data[0].iq_data.i, [0.5, 0.5])
+        np.testing.assert_allclose(scan.detector_data[0].iq_data.e, expected_first_error)
+        assert scan.detector_data[0].iq_data.q == [1.0, 2.0]
+        assert scan.detector_data[0].iq_data.t == [7.0, 8.0]
+        np.testing.assert_allclose(scan.detector_data[1].iq_data.i, [0.25, 0.25])
+        np.testing.assert_allclose(scan.detector_data[1].iq_data.e, expected_second_error)
+
+
 class TestScanReadXYFile:
     """Tests for Scan.read_xy_file."""
 


### PR DESCRIPTION
# Description of the changes

Refactor the data reduction pipeline to output scaled (and unscaled) data for all detector harmonics (not just the first), not just the primary detector bank. It also introduces a formal JSON schema for setup files, reworks the physics of monitor normalization, rocking curve centering, and data rescaling, and cleans up the Experiment API.

-  `save_all_harmonics` — When enabled in the JSON config, output files for all detector banks (harmonics) are written into bank_N/ subdirectories for both unscaled and scaled data.
- JSON schema (usansred.json) —to validate setup files, inject defaults and surface clear validation errors.
- read_config() now returns a single unified dict with schema validation and default injection applied to both JSON and CSV inputs.
- Reworked reduction physics — Monitor normalization, scan stitching (now using inverse-variance weighting), rocking curve centering (new Gaussian-fit step), and data rescaling (using the physics-based horizontal_rocking_width(order) formula per harmonic) 
- Experiment API cleanup — Several fields were renamed or removed (config → config_file, logbin → log_binning, darwin_width/min_q/step_per_dec dropped), with CSV backwards compatibility preserved via amend_log_binning().
- User docs lead with the JSON format and document new options;
- unit and integration tests were expanded to cover the new pipeline steps
- AGENTS.md for AI guidance.

Check all that apply:
- [x] updated documentation
- [x] Source added/refactored
- [x] Added unit tests
- [x] Added integration tests

**References:**
- Links to IBM EWM items: [14677](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.apt.viewPlan&planMode=com.ibm.team.apt.viewmodes.internal.workBreakdown&id=_pl3qYBfdEfGYaoRPRJ8SOg)

# :warning: Manual test for the reviewer
<!-- Instructions for testing here. -->

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
