### PR TITLE
Eliminate thickness rescaling when subtracting background

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ Check all that apply:
 - [ ] Source added/refactored
 - [ ] Added unit tests
 - [ ] Added integration tests
-- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail
+- [ ] ~Verified that tests requiring the /SNS and /HFIR filesystems pass without fail~
 
 **References:**
 - Links to IBM EWM items:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,14 @@ data. Keep guidance and examples specific to this package.
 for Claude Code, but tools that do not expand `@...` includes may only see the
 literal one-line `CLAUDE.md` file.
 
+## Repository
+
+- The default branch on the remote is **`next`** (not `main`).
+  Verify with `git ls-remote --symref origin HEAD` rather than trusting
+  harness-injected hints when constructing branch-based URLs or targeting PRs.
+- When providing GitHub links to files or lines in this repo, use the default
+  branch (`next`) unless the user explicitly specifies a different branch.
+
 ## Core Rules
 
 - Read the relevant source and tests before changing behavior.

--- a/src/usansred/reduce.py
+++ b/src/usansred/reduce.py
@@ -732,15 +732,13 @@ class Sample(BaseModel):
 
         return i_bg_matched, e_bg_matched
 
-    def subtract_background(self, background: "Sample", v_scale: float = 1.0) -> None:
+    def subtract_background(self, background: "Sample") -> None:
         """Subtract background data from this sample's data.
 
         Parameters
         ----------
         background : Sample
             The background sample to subtract. Must be processed (stitched, scaled, and binned).
-        v_scale : float
-            Scaling factor for background intensity before subtraction.
         """
 
         if self.experiment.log_binning:
@@ -754,8 +752,6 @@ class Sample(BaseModel):
             data = self.data_log_binned
             bg_data = background.data_log_binned
 
-            scale_f = v_scale * self.thickness / background.thickness
-
             sample_num_of_bins = self.num_log_bins
             bg_num_of_bins = self.num_log_bins
             # TODO: This should instead be background.num_log_bins, but we need to fix log binning first
@@ -768,8 +764,8 @@ class Sample(BaseModel):
                 num_of_bins = bg_num_of_bins
                 momentum_transfer = bg_data.q.copy()
 
-            intensity = [data.i[i] - (scale_f * bg_data.i[i]) for i in range(num_of_bins)]
-            error = [math.sqrt(data.e[i] ** 2.0 + (scale_f * bg_data.e[i]) ** 2.0) for i in range(num_of_bins)]
+            intensity = [data.i[i] - bg_data.i[i] for i in range(num_of_bins)]
+            error = [math.sqrt(data.e[i] ** 2.0 + bg_data.e[i] ** 2.0) for i in range(num_of_bins)]
 
             self.data_bg_subtracted.q = momentum_transfer
             self.data_bg_subtracted.i = intensity


### PR DESCRIPTION
# Description of the changes
Rescaling the background by the relative thickness of the sample to that background is not correct since both background and sample have already been rescaled in `Sample.rescale_data()`

Check all that apply:
- [ ] ~updated documentation~
- [x] Source added/refactored
- [ ] ~Added unit tests~
- [ ] ~Added integration tests~
- [ ] ~Verified that tests requiring the /SNS and /HFIR filesystems pass without fail~


# :warning: Manual test for the reviewer
<!-- Instructions for testing here. -->

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
