### PR TITLE
omit types for some ignore-rules

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -2,17 +2,15 @@ ignore:
   - package:
       name: python
       version: "3.11.*"
-      type: binary
-    reason: "Python 3.11.x binary detection; vulnerabilities tracked upstream."
+    reason: "version pinned by Mantid 6.15.0"
 
   - package:
       name: gstreamer
       version: "1.26.11"
       type: conda
-    reason: "gstreamer 1.26.11 has multiple CVEs with no fix available yet; ignored until conda-forge ships a patched version."
+    reason: "version pinned by Mantid 6.15.*"
 
   - package:
       name: pillow
       version: "11.3.0"
-      type: conda
-    reason: "pillow 11.3.0 is pinned by mantid 6.15.0"
+    reason: "version pinned by Mantid 6.15.*"


### PR DESCRIPTION
# Description of the changes

This PR updates the repository’s Grype configuration to broaden (or unblock) specific vulnerability ignore rules by omitting `package.type` on selected entries, aligning the ignores with Mantid 6.15.x–pinned dependency versions during CI environment scans.

**Changes:**
- Removed `type` from the `python` ignore rule and updated its reason to reference Mantid pinning.
- Updated the `gstreamer` ignore rule’s reason text (keeping `type: conda`).
- Removed `type` from the `pillow` ignore rule and updated its reason to reference Mantid pinning.

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
