### PR TITLE
deploy should happen after the conda package has been uploaded

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -150,7 +150,7 @@ jobs:
   # Trigger GitLab dev deploy pipeline
   deploy-dev:
     runs-on: ubuntu-latest
-    needs: build
+    needs: publish
     if: github.ref == 'refs/heads/next'
     steps:
       - name: Get Environment Name


### PR DESCRIPTION
# Description of the changes

This pull request updates the CI/CD workflow so the `deploy-dev` job waits for the conda package upload step to complete, ensuring dev deployment is triggered only after the package is successfully published to Anaconda.

**Changes:**
- Changed `deploy-dev` to depend on the `publish` job instead of `build`, enforcing correct deployment ordering.

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
